### PR TITLE
[Ad Image] - Add John and hashcat

### DIFF
--- a/ad.dockerfile
+++ b/ad.dockerfile
@@ -26,7 +26,7 @@ RUN /root/sources/install.sh install_base
 # this is a temporary limitation
 RUN /root/sources/install.sh install_misc_tools
 RUN /root/sources/install.sh install_wordlists_tools
-# RUN /root/sources/install.sh install_cracking_tools
+RUN /root/sources/install.sh install_cracking_tools
 # RUN /root/sources/install.sh install_osint_tools
 RUN /root/sources/install.sh install_web_tools
 RUN /root/sources/install.sh install_c2_tools

--- a/sources/zsh/history
+++ b/sources/zsh/history
@@ -128,6 +128,7 @@ GetUserSPNs.py -outputfile Kerberoastables.txt -dc-ip 192.168.56.101 BREAKING.BA
 GetUserSPNs.py -outputfile Kerberoastables.txt -hashes :a88baa3fdc8f581ee0fb05d7054d43e4 -dc-ip 192.168.56.101 BREAKING.BAD/Administrator
 hashcat --status --hash-type 13100 --attack-mode 0 Kerberoastables.txt `fzf-wordlists`
 john --format=krb5tgs --wordlist=`fzf-wordlists` Kerberoastables.txt
+john --format=NT --wordlist=/usr/share/wordlists/rockyou.txt --fork=10 HashToPwn.txt --rules=all
 polenum -u anonymous -p anonymous -d DC01.BREAKING.BAD
 cme smb 192.168.56.101 -u '' -p '' --pass-pol
 addcomputer.py -computer-name 'SHUTDOWN$' -computer-pass '123soleil!' -dc-host DC01 -domain-netbios BREAKING.BAD 'BREAKING.BAD/anonymous:anonymous'


### PR DESCRIPTION
Pull up, 
During internal testing we regularly need to break passwords, either database or NTLM hashes to taunt users 

In any case I think it is relevant to have a suite of tools like john and hashcat available on the AD image

Currently john is only available in the full version, personally I mainly use the AD image soo.. :)

By the way, I think it's a good idea to separate the repo's, I think it's cleaner! 

