### PR TITLE
Adding custom BloodHound queries

### DIFF
--- a/sources/bloodhound/customqueries.json
+++ b/sources/bloodhound/customqueries.json
@@ -227,7 +227,7 @@
             "category": "A one-man wolf pack",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE g.objectid ENDS WITH "S-1-1-0" OR g.objectid ENDS WITH "-513" OR g.objectid ENDS WITH "S-1-5-11" OR g.objectid ENDS WITH "-515" RETURN p"
+                "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE g.objectid ENDS WITH 'S-1-1-0' OR g.objectid ENDS WITH '-513' OR g.objectid ENDS WITH 'S-1-5-11' OR g.objectid ENDS WITH '-515' RETURN p"
             }]
         },
         {

--- a/sources/bloodhound/customqueries.json
+++ b/sources/bloodhound/customqueries.json
@@ -215,6 +215,22 @@
             }]
         },
         {
+            "name": "Groups or users with the AddAllowedToAct right on a computer",
+            "category": "A one-man wolf pack",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE NOT g.highvalue RETURN p"
+            }]
+        },
+        {
+            "name": "Exploitable cases from any authenticated user with the AddAllowedToAct right on a computer",
+            "category": "A one-man wolf pack",
+            "queryList": [{
+                "final": true,
+                "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE g.objectid ENDS WITH "S-1-1-0" OR g.objectid ENDS WITH "-513" OR g.objectid ENDS WITH "S-1-5-11" OR g.objectid ENDS WITH "-515" RETURN p"
+            }]
+        },
+        {
             "name": "Groups that contain the word 'admin'",
             "category": "A one-man wolf pack",
             "queryList": [{

--- a/sources/bloodhound/customqueries.json
+++ b/sources/bloodhound/customqueries.json
@@ -216,7 +216,7 @@
         },
         {
             "name": "Groups or users with the AddAllowedToAct right on a computer",
-            "category": "A one-man wolf pack",
+            "category": "A nerdy hillbilly",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE NOT g.highvalue RETURN p"
@@ -224,7 +224,7 @@
         },
         {
             "name": "Exploitable cases from any authenticated user with the AddAllowedToAct right on a computer",
-            "category": "A one-man wolf pack",
+            "category": "A nerdy hillbilly",
             "queryList": [{
                 "final": true,
                 "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE g.objectid ENDS WITH 'S-1-1-0' OR g.objectid ENDS WITH '-513' OR g.objectid ENDS WITH 'S-1-5-11' OR g.objectid ENDS WITH '-515' RETURN p"


### PR DESCRIPTION
Dirk-jan proposed on his new research blog post (Abusing forgotten permissions on computer objects in Active Directory), two queries to find AddAllowedToAct rights on computers. I decided to add these queries on the "A one-man wolf pack" category as it represents groups (mainly). 
By the way, the feature is present in version 1.3.0 of BloodHound.py.

Query 1: Groups or users with the AddAllowedToAct right on a computer
Query 2: Exploitable cases from any authenticated user with the AddAllowedToAct right on a computer

TL;DR: if you have the AddAllowedToAct right on a computer, you can configure RBCD on it.