### PR TITLE
Update custom BloodHound queries

### DIFF
--- a/sources/bloodhound/customqueries.json
+++ b/sources/bloodhound/customqueries.json
@@ -223,19 +223,19 @@
             }]
         },
         {
-            "name": "Groups or users with the AddAllowedToAct right on a computer",
+            "name": "Groups or users with the AllowedToActOnBehalfOfOtherIdentity right on a computer",
             "category": "A nerdy hillbilly",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE NOT g.highvalue RETURN p"
+                "query": "MATCH p=(g)-[:WriteAccountRestrictions]->(c:Computer) WHERE NOT g.highvalue RETURN p"
             }]
         },
         {
-            "name": "Exploitable cases from any authenticated user with the AddAllowedToAct right on a computer",
+            "name": "Exploitable cases from any authenticated user with the AllowedToActOnBehalfOfOtherIdentity right on a computer",
             "category": "A nerdy hillbilly",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g)-[:AddAllowedToAct]->(c:Computer) WHERE g.objectid ENDS WITH 'S-1-1-0' OR g.objectid ENDS WITH '-513' OR g.objectid ENDS WITH 'S-1-5-11' OR g.objectid ENDS WITH '-515' RETURN p"
+                "query": "MATCH p=(g)-[:WriteAccountRestrictions]->(c:Computer) WHERE g.objectid ENDS WITH 'S-1-1-0' OR g.objectid ENDS WITH '-513' OR g.objectid ENDS WITH 'S-1-5-11' OR g.objectid ENDS WITH '-515' RETURN p"
             }]
         },
         {

--- a/sources/bloodhound/customqueries.json
+++ b/sources/bloodhound/customqueries.json
@@ -223,19 +223,11 @@
             }]
         },
         {
-            "name": "Groups or users with the AllowedToActOnBehalfOfOtherIdentity right on a computer",
+            "name": "Objects with the AddAllowedToAct or WriteAccountRestrictions right on a computer",
             "category": "A nerdy hillbilly",
             "queryList": [{
                 "final": true,
-                "query": "MATCH p=(g)-[:WriteAccountRestrictions]->(c:Computer) WHERE NOT g.highvalue RETURN p"
-            }]
-        },
-        {
-            "name": "Exploitable cases from any authenticated user with the AllowedToActOnBehalfOfOtherIdentity right on a computer",
-            "category": "A nerdy hillbilly",
-            "queryList": [{
-                "final": true,
-                "query": "MATCH p=(g)-[:WriteAccountRestrictions]->(c:Computer) WHERE g.objectid ENDS WITH 'S-1-1-0' OR g.objectid ENDS WITH '-513' OR g.objectid ENDS WITH 'S-1-5-11' OR g.objectid ENDS WITH '-515' RETURN p"
+                "query": "MATCH p=(g)-[:AddAllowedToAct|WriteAccountRestrictions]->(c:Computer) RETURN p"
             }]
         },
         {


### PR DESCRIPTION
I've made a PR (#48) about queries allowing you to find when there's a 'AllowedToActOnBehalfOfOtherIdentity' right on a computer.

I'm guessing Dirk-jan modified his edge from 'AddAllowedToAct' to 'WriteAccountRestrictions' in part due to his PR for SharpHound (https://github.com/BloodHoundAD/SharpHoundCommon/pull/34).

Old queries (that are still present in his blog) won't work, therefore I'm adding the modified version.