### PR TITLE
Change Trilium binding address to localhost

### DIFF
--- a/sources/trilium/config.ini
+++ b/sources/trilium/config.ini
@@ -13,7 +13,7 @@ noBackup=false
 
 [Network]
 # host setting is relevant only for web deployments - set the host on which the server will listen
-# host=0.0.0.0
+host=localhost
 # port setting is relevant only for web deployments, desktop builds run on a fixed port (changeable with TRILIUM_PORT environment variable)
 port=1991
 # true for TLS/SSL/HTTPS (secure), false for HTTP (unsecure).


### PR DESCRIPTION
Trilium is using the default `exegol4thewin` password and exposing it on all the interfaces.
I believe that is a security concern and that the service should only be exposed on `localhost` by default.