### PR TITLE
Add WES-NG

### DIFF
--- a/sources/assets/shells/aliases.d/wesng
+++ b/sources/assets/shells/aliases.d/wesng
@@ -1,0 +1,3 @@
+wes --update
+wes systeminfo.txt
+wes --impact "Remote Code Execution"

--- a/sources/assets/shells/aliases.d/wesng
+++ b/sources/assets/shells/aliases.d/wesng
@@ -1,3 +1,0 @@
-wes --update
-wes systeminfo.txt
-wes --impact "Remote Code Execution"

--- a/sources/assets/shells/history.d/wesng
+++ b/sources/assets/shells/history.d/wesng
@@ -1,0 +1,3 @@
+wes --update
+wes systeminfo.txt
+wes --impact "Remote Code Execution" systeminfo.txt

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -203,10 +203,9 @@ function install_wesng() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing wesng"
     pipx install --system-site-packages git+https://github.com/bitsadmin/wesng
-    pipx inject wesng chardet # Not mendatory but stop the warning
     add-history wesng
     add-test-command "wes --help"
-    add-to-list "wesng,https://github.com/bitsadmin/wesng,WES-NG is a tool based on the output of Windows's systeminfo utility which provides the list of vulnerabilities the OS is vulnerable to, including any exploits for these vulnerabilities."
+    add-to-list "wesng,https://github.com/bitsadmin/wesng,WES-NG is a tool based on the output of Windows's systeminfo utility which provides the list of vulnerabilities the OS is vulnerable to including any exploits for these vulnerabilities."
 }
 
 

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -203,6 +203,7 @@ function install_wesng() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing wesng"
     pipx install --system-site-packages git+https://github.com/bitsadmin/wesng
+    pipx inject wesng chardet
     add-history wesng
     add-test-command "wes --help"
     add-to-list "wesng,https://github.com/bitsadmin/wesng,WES-NG is a tool based on the output of Windows's systeminfo utility which provides the list of vulnerabilities the OS is vulnerable to including any exploits for these vulnerabilities."

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -203,7 +203,6 @@ function install_wesng() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing wesng"
     pipx install --system-site-packages git+https://github.com/bitsadmin/wesng
-    pipx inject wesng chardet
     add-history wesng
     add-test-command "wes --help"
     add-to-list "wesng,https://github.com/bitsadmin/wesng,WES-NG is a tool based on the output of Windows's systeminfo utility which provides the list of vulnerabilities the OS is vulnerable to including any exploits for these vulnerabilities."

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -199,6 +199,17 @@ function install_uploader() {
     add-to-list "uploader,https://github.com/Frozenka/uploader,Tool for quickly downloading files to a remote machine based on the target operating system"
 }
 
+function install_wesng() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing wesng"
+    pipx install --system-site-packages git+https://github.com/bitsadmin/wesng
+    pipx inject wesng chardet # Not mendatory but stop the warning
+    add-history wesng
+    add-test-command "wes --help"
+    add-to-list "wesng,https://github.com/bitsadmin/wesng,WES-NG is a tool based on the output of Windows's systeminfo utility which provides the list of vulnerabilities the OS is vulnerable to, including any exploits for these vulnerabilities."
+}
+
+
 # Package dedicated to offensive miscellaneous tools
 function package_misc() {
     set_env
@@ -220,6 +231,7 @@ function package_misc() {
     install_cyberchef       # A web based toolbox
     install_creds           # A default credentials vault
     install_uploader        # uploader for fast file upload
+    install_wesng           # Search Windows vulnerability via systeminfo
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package misc completed in $elapsed_time seconds."


### PR DESCRIPTION
# Description

WES-NG is a tool based on the output of Windows' systeminfo utility which provides the list of vulnerabilities the OS is vulnerable to, including any exploits for these vulnerabilities. Every Windows OS between Windows XP and Windows 11, including their Windows Server counterparts, is supported.

Link : https://github.com/bitsadmin/wesng

It's a good add to exegol for pentest perspective :)

# Point of attention

Nothing special.
