### PR TITLE
Add custom arsenal cheatsheets feature for my resources

### DIFF
--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -278,8 +278,8 @@ function _trust_ca_cert_in_firefox() {
 function deploy_arsenal_cheatsheet () {
 # Function to add custom cheatsheets into arsenal
   colorecho "Deploying custom arsenal cheatsheet"
-  if [[ ! -d "$MY_SETUP_PATH/my-cheats" ]]; then
-      mkdir -p "$MY_SETUP_PATH/my-cheats"
+  if [[ ! -d "$MY_SETUP_PATH/arsenal-cheats" ]]; then
+      mkdir -p "$MY_SETUP_PATH/arsenal-cheats"
   fi
 }
 

--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -275,6 +275,17 @@ function _trust_ca_cert_in_firefox() {
   certutil -A -n "$2" -t "TC" -i "$1" -d ~/.mozilla/firefox/*.Exegol
 }
 
+function deploy_arsenal_cheatsheet () {
+# Fuction to add custom cheatsheets into arsenal
+  colorecho "Deploying custom arsenal cheatsheet"
+  if [[ -d "$MY_SETUP_PATH/cheatsheet" ]]; then
+    mkdir -p ~/.cheats
+    cp -r "$MY_SETUP_PATH/cheatsheet" ~/.cheats
+  else
+    mkdir -p "$MY_SETUP_PATH/cheatsheet"
+  fi
+}
+
 # Starting
 # This procedure is supposed to be executed only once at the first startup, using a lockfile check
 
@@ -292,6 +303,7 @@ deploy_python3
 deploy_firefox_addons
 deploy_bloodhound
 trust_ca_certs_in_firefox
+deploy_arsenal_cheatsheet
 
 run_user_setup
 

--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -276,7 +276,7 @@ function _trust_ca_cert_in_firefox() {
 }
 
 function deploy_arsenal_cheatsheet () {
-# Fuction to add custom cheatsheets into arsenal
+# Function to add custom cheatsheets into arsenal
   colorecho "Deploying custom arsenal cheatsheet"
   if [[ -d "$MY_SETUP_PATH/cheatsheet" ]]; then
     mkdir -p ~/.cheats

--- a/sources/assets/exegol/load_supported_setups.sh
+++ b/sources/assets/exegol/load_supported_setups.sh
@@ -278,11 +278,8 @@ function _trust_ca_cert_in_firefox() {
 function deploy_arsenal_cheatsheet () {
 # Function to add custom cheatsheets into arsenal
   colorecho "Deploying custom arsenal cheatsheet"
-  if [[ -d "$MY_SETUP_PATH/cheatsheet" ]]; then
-    mkdir -p ~/.cheats
-    cp -r "$MY_SETUP_PATH/cheatsheet" ~/.cheats
-  else
-    mkdir -p "$MY_SETUP_PATH/cheatsheet"
+  if [[ ! -d "$MY_SETUP_PATH/my-cheats" ]]; then
+      mkdir -p "$MY_SETUP_PATH/my-cheats"
   fi
 }
 

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -51,7 +51,12 @@ function install_uberfile() {
 
 function install_arsenal() {
     colorecho "Installing arsenal"
-    pipx install --system-site-packages git+https://github.com/Orange-Cyberdefense/arsenal
+    git -C /opt/tools/ clone --depth 1 https://github.com/Orange-Cyberdefense/arsenal
+    cd /opt/tools/arsenal || exit
+    python3 -m venv --system-site-packages ./venv/
+    source ./venv/bin/activate
+    pip3 install -r requirements.txt
+    deactivate
     add-aliases arsenal
     add-history arsenal
     add-test-command "arsenal --version"

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -51,12 +51,7 @@ function install_uberfile() {
 
 function install_arsenal() {
     colorecho "Installing arsenal"
-    git -C /opt/tools/ clone --depth 1 https://github.com/Orange-Cyberdefense/arsenal
-    cd /opt/tools/arsenal || exit
-    python3 -m venv --system-site-packages ./venv/
-    source ./venv/bin/activate
-    pip3 install -r requirements.txt
-    deactivate
+    pipx install --system-site-packages git+https://github.com/Orange-Cyberdefense/arsenal
     add-aliases arsenal
     add-history arsenal
     add-test-command "arsenal --version"


### PR DESCRIPTION
# Description

This PR is a evolution of my resource function to add the possibility for Exegol users to have their own cheatsheets inside Arsenal.

If there are some cheatsheets inside cheatsheet folder in "my resources" a copy is done to /root/.cheats (valid path for arsenal). Else, the folder is created for future use.

Pretty basic feature but that can really enforce the customisation of Exegol. 

# Point of attention

I hope my PR is OK :)
