### PR TITLE
installation of remote method guesser and beanshooter at build

### DIFF
--- a/sources/assets/firefox/setup.py
+++ b/sources/assets/firefox/setup.py
@@ -31,6 +31,7 @@ urls = [
     "https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/"
 ]
 
+
 # Define regex
 reurl = r"(https:\/\/addons\.mozilla\.org\/firefox\/downloads\/file\/[0-9]+\/)([a-zA-Z0-9\-\_\.]+\.xpi)"
 reid = r'"id": "([^"]+)"'

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -368,7 +368,6 @@ function package_network() {
     install_rustscan
     install_legba                   # Login Scanner
     install_ssh-audit               # SSH server audit
-    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package network completed in $elapsed_time seconds."

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -298,6 +298,27 @@ function install_ssh-audit() {
     add-to-list "ssh-audit,https://github.com/jtesta/ssh-audit,ssh-audit is a tool to test SSH server configuration for best practices."
 }
 
+
+
+function install_remote-method-guesser() {
+    colorecho "Installing remote method guesser (rmg)"
+    git -C /opt/tools clone --depth 1 https://github.com/qtc-de/remote-method-guesser
+    cd /opt/tools/remote-method-guesser || exit
+    mvn package
+    cat << 'EOF' > /usr/local/bin/rmg
+#!/bin/bash
+java -jar /opt/tools/remote-method-guesser/target/rmg-5.1.0-jar-with-dependencies.jar "$@"
+EOF
+    chmod +x /usr/local/bin/rmg
+    colorecho "rmg installed successfully. Run 'rmg -help' to use the application."
+    add-test-command "rmg --help"
+    add-to-list "emote-method-guesser (rmg) is a Java RMI vulnerability scanner and can be used to identify and verify common security vulnerabilities on Java RMI endpoints."
+}
+
+
+
+
+
 # Package dedicated to network pentest tools
 function package_network() {
     set_env

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -368,9 +368,9 @@ function package_network() {
     install_rustscan
     install_legba                   # Login Scanner
     install_ssh-audit               # SSH server audit
-    post_install
     install_remote_method_guesser   # Remote methode guesser
     install_beanshooter             # beanshooter
+    post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package network completed in $elapsed_time seconds."

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -368,6 +368,7 @@ function package_network() {
     install_rustscan
     install_legba                   # Login Scanner
     install_ssh-audit               # SSH server audit
+    post_install
     install_remote_method_guesser   # Remote methode guesser
     install_beanshooter             # beanshooter
     end_time=$(date +%s)

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -368,6 +368,8 @@ function package_network() {
     install_rustscan
     install_legba                   # Login Scanner
     install_ssh-audit               # SSH server audit
+    install_remote_method_guesser   # Remote methode guesser
+    install_beanshooter             # beanshooter
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))
     colorecho "Package network completed in $elapsed_time seconds."

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -298,19 +298,23 @@ function install_ssh-audit() {
     add-to-list "ssh-audit,https://github.com/jtesta/ssh-audit,ssh-audit is a tool to test SSH server configuration for best practices."
 }
 
-
-
-function install_remote-method-guesser() {
+function install_remote_method_guesser() {
     colorecho "Installing remote method guesser (rmg)"
     git -C /opt/tools clone --depth 1 https://github.com/qtc-de/remote-method-guesser
     cd /opt/tools/remote-method-guesser || exit
     mvn package
     cat << 'EOF' > /usr/local/bin/rmg
 #!/bin/bash
-java -jar /opt/tools/remote-method-guesser/target/rmg-5.1.0-jar-with-dependencies.jar "$@"
+JAR=$(ls -t /opt/tools/remote-method-guesser/target/*-jar-with-dependencies.jar 2>/dev/null | head -n 1)
+echo "$JAR"
+if [[ -z "$JAR" ]]; then
+    echo "JAR file not found in /opt/tools/remote-method-guesser/target/"
+    exit 1
+fi
+java -jar "$JAR" "$@"
 EOF
     chmod +x /usr/local/bin/rmg
-    colorecho "rmg installed successfully. Run 'rmg -help' to use the application."
+    colorecho "rmg installed successfully. Run 'rmg --help' to use the application."
     add-test-command "rmg --help"
     add-to-list "Remote-method-guesser (rmg) is a Java RMI vulnerability scanner and can be used to identify and verify common security vulnerabilities on Java RMI endpoints."
 }

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -312,11 +312,29 @@ EOF
     chmod +x /usr/local/bin/rmg
     colorecho "rmg installed successfully. Run 'rmg -help' to use the application."
     add-test-command "rmg --help"
-    add-to-list "emote-method-guesser (rmg) is a Java RMI vulnerability scanner and can be used to identify and verify common security vulnerabilities on Java RMI endpoints."
+    add-to-list "Remote-method-guesser (rmg) is a Java RMI vulnerability scanner and can be used to identify and verify common security vulnerabilities on Java RMI endpoints."
 }
 
-
-
+function install_beanshooter() {
+    colorecho "Installing beanshooter"
+    git -C /opt/tools clone --depth 1 https://github.com/qtc-de/beanshooter
+    cd /opt/tools/beanshooter || exit
+    mvn package
+    cat << 'EOF' > /usr/local/bin/beanshooter
+#!/bin/bash
+JAR=$(ls -t /opt/tools/beanshooter/target/*-jar-with-dependencies.jar 2>/dev/null | head -n 1)
+echo "$JAR"
+if [[ -z "$JAR" ]]; then
+    echo "JAR file not found in /opt/tools/beanshooter/target/"
+    exit 1
+fi
+java -jar "$JAR" "$@"
+EOF
+    chmod +x /usr/local/bin/beanshooter
+    colorecho "beanshooter installed successfully. Run 'beanshooter --help' to use the application."
+    add-test-command "beanshooter --help"
+    add-to-list "beanshooter is a JMX enumeration and attacking tool, which helps to identify common vulnerabilities on JMX endpoints."
+}
 
 
 # Package dedicated to network pentest tools

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -316,7 +316,7 @@ EOF
     chmod +x /usr/local/bin/rmg
     colorecho "rmg installed successfully. Run 'rmg --help' to use the application."
     add-test-command "rmg --help"
-    add-to-list "Remote-method-guesser (rmg) is a Java RMI vulnerability scanner and can be used to identify and verify common security vulnerabilities on Java RMI endpoints."
+    add-to-list "remote_method_guesser,https://github.com/qtc-de/remote-method-guesser (rmg) is a Java RMI vulnerability scanner and can be used to identify and verify common security vulnerabilities on Java RMI endpoints."
 }
 
 function install_beanshooter() {
@@ -337,7 +337,7 @@ EOF
     chmod +x /usr/local/bin/beanshooter
     colorecho "beanshooter installed successfully. Run 'beanshooter --help' to use the application."
     add-test-command "beanshooter --help"
-    add-to-list "beanshooter is a JMX enumeration and attacking tool, which helps to identify common vulnerabilities on JMX endpoints."
+    add-to-list "beanshooter,https://github.com/qtc-de/beanshooter is a JMX enumeration and attacking tool, which helps to identify common vulnerabilities on JMX endpoints."
 }
 
 


### PR DESCRIPTION
# Description

> This PR addressed the installation of remote method guesser and beanshooter 2 wonderful tools used in java RMI pentest

# Point of attention
> The install doesnot check for the presence of maven on the exegol image but i tested with the latest nightly image so i presume it is installed already
