### PR TITLE
Rollback on CI auto and manual builds

### DIFF
--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -7,9 +7,6 @@ on:
     paths-ignore:
 #      - ".github/**"
       - "**.md"
-  schedule:
-    - cron: '0 0 * * 5'  # Run at midnight every Friday
-  workflow_dispatch:  # Enable manual triggering from GitHub interface
 
 env:
   # fake local registry for base image


### PR DESCRIPTION
Nightly build pipeline was modified in latest release #470 so that it builds every week and can be triggered manually as well.
However, we forgot to target the `dev` branch at checkout, effectively building outdated images