### PR TITLE
fix(reverse/pwninit): missing tools

### DIFF
--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -135,7 +135,7 @@ function install_jd-gui() {
 function install_pwninit() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing pwninit"
-    fapt liblzma-dev
+    fapt liblzma-dev patchelf elfutils
     # Sourcing rustup shell setup, so that rust binaries are found when installing cme
     source "$HOME/.cargo/env"
     cargo install pwninit


### PR DESCRIPTION
See https://github.com/io12/pwninit/issues/260, `patchelf` and `elfutils` are missing to use it entirely.