### PR TITLE
feat(reverse): upgrade ghidra

### DIFF
--- a/sources/assets/desktop/applications/ghidra.desktop
+++ b/sources/assets/desktop/applications/ghidra.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Ghidra
 Comment=Decompiler
-Exec=bash -c "JAVA_HOME=/usr/lib/jvm/java-11-openjdk /opt/tools/ghidra_10.1.2_PUBLIC/ghidraRun"
-Icon=/opt/tools/ghidra_10.1.2_PUBLIC/docs/images/GHIDRA_1.png
+Exec=bash -c "JAVA_HOME=/usr/lib/jvm/java-11-openjdk /opt/tools/ghidra/ghidraRun"
+Icon=/opt/tools/ghidra/docs/images/GHIDRA_1.png
 Terminal=false
 Type=Application
 StartupNotify=true

--- a/sources/assets/shells/aliases.d/ghidra
+++ b/sources/assets/shells/aliases.d/ghidra
@@ -1,1 +1,1 @@
-alias ghidra='JAVA_HOME=/usr/lib/jvm/java-11-openjdk /opt/tools/ghidra_10.1.2_PUBLIC/ghidraRun'
+alias ghidra='JAVA_HOME=/usr/lib/jvm/java-11-openjdk /opt/tools/ghidra/ghidraRun'

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -94,9 +94,12 @@ function install_radare2() {
 function install_ghidra() {
     # CODE-CHECK-WHITELIST=add-test-command
     colorecho "Installing Ghidra"
-    wget -P /tmp/ "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.1.2_build/ghidra_10.1.2_PUBLIC_20220125.zip"
-    unzip -q /tmp/ghidra_10.1.2_PUBLIC_20220125.zip -d /opt/tools # -q because too much useless verbose
-    rm /tmp/ghidra_10.1.2_PUBLIC_20220125.zip
+    local ghidra_url
+    ghidra_url=$(curl --location --silent "https://api.github.com/repos/NationalSecurityAgency/ghidra/releases/latest" | grep 'browser_download_url' | grep -o 'https://[^"]*')
+    curl --location -o /tmp/ghidra.zip "$ghidra_url"
+    unzip -q /tmp/ghidra.zip -d /opt/tools # -q because too much useless verbose
+    mv -v /opt/tools/ghidra_* /opt/tools/ghidra # ghidra always has a version number in the unzipped folder, lets make it consistent
+    rm /tmp/ghidra.zip
     add-aliases ghidra
     add-history ghidra
     # TODO add-test-command GUI app


### PR DESCRIPTION
Actual 10.1.2 was released 2 years ago :sob: 
Let's always download the latest one, also, you should think about a way to test GUI only tools (#481)...