### PR TITLE
feat(reverse): upgrade idafree

### DIFF
--- a/sources/assets/shells/aliases.d/ida
+++ b/sources/assets/shells/aliases.d/ida
@@ -1,1 +1,1 @@
-alias ida='/opt/tools/idafree-7.7/ida64'
+alias ida='/opt/tools/idafree/ida64'

--- a/sources/install/package_reverse.sh
+++ b/sources/install/package_reverse.sh
@@ -108,10 +108,10 @@ function install_ida() {
     colorecho "Installing IDA"
     if [[ $(uname -m) = 'x86_64' ]]
     then
-        wget -P /tmp/ "https://out7.hex-rays.com/files/idafree77_linux.run"
-        chmod +x /tmp/idafree77_linux.run
-        /tmp/idafree77_linux.run --mode unattended --prefix /opt/tools/idafree-7.7
-        rm /tmp/idafree77_linux.run
+        wget "https://out7.hex-rays.com/files/idafree84_linux.run" -O /tmp/idafree_linux.run
+        chmod +x /tmp/idafree_linux.run # This is the setup wizard
+        /tmp/idafree_linux.run --mode unattended --prefix /opt/tools/idafree
+        rm /tmp/idafree_linux.run
     else
         criticalecho-noexit "This installation function doesn't support architecture $(uname -m), IDA Free only supports x86/x64" && return
     fi


### PR DESCRIPTION
Actual 7.7 was released 4 years ago 😭
The 8.4 (feb 2024) is the latest version you can download without creating an account on https://my.hex-rays.com/dashboard/download-center/ (the 9.1 is the official latest version)...
Also, you should think about a way to test GUI only tools (#481)...