### PR TITLE
feat: provide `fapt` alias in exegol

### DIFF
--- a/sources/assets/shells/aliases.d/_init
+++ b/sources/assets/shells/aliases.d/_init
@@ -11,4 +11,5 @@ alias sed-comment-line='sed -E "/^\s*([#;]|\/\/).*$/d"'
 alias http-put-server='python3 /opt/resources/linux/http-put-server.py --bind 0.0.0.0'
 alias ws='cd /workspace'
 alias systemctl="echo 'Systemctl cannot be used inside the container. Please use the \"service\" command instead.' && false"
+alias fapt='if [ -z "$( ls -A /var/lib/apt/lists/ )" ]; then apt-get update; fi && apt-fast install -y --no-install-recommends "$@"'
 alias history-dump='history -E | tail -n +$(($(history | grep "# -=-=-=-=-=-=-=- YOUR COMMANDS BELOW -=-=-=-=-=-=-=- #" | grep -v "grep" | tail -n1 | cut -d "#" -f1 | tr -d " ") + 1))'


### PR DESCRIPTION
i love using `fapt` during setup and i regret not having it directly in exegol :)