### PR TITLE
perf: no more useless build dependencies

### DIFF
--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -145,11 +145,10 @@ function install_objectwalker() {
 function install_tig() {
     # CODE-CHECK-WHITELIST=add-aliases,add-history
     colorecho "Installing tig"
-    git -C /opt/tools clone --depth 1 https://github.com/jonas/tig.git
-    cd /opt/tools/tig || exit
+    git -C /tmp clone --depth 1 https://github.com/jonas/tig.git
+    cd /tmp/tig || exit
     make -j
-    make install clean
-    mv /root/bin/tig /opt/tools/bin/tig
+    make install bindir=/opt/tools/bin sysconfdir=/etc
     # Need add-history ?
     add-test-command "tig --help"
     add-to-list "tig,https://github.com/jonas/tig,Tig is an ncurses-based text-mode interface for git."

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -433,8 +433,8 @@ function install_geopincer() {
 function install_yalis() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing Yalis"
-    git -C /opt/tools clone --depth 1 https://github.com/EatonChips/yalis
-    cd /opt/tools/yalis || exit
+    git -C /tmp clone --depth 1 https://github.com/EatonChips/yalis
+    cd /tmp/yalis || exit
     go build .
     mv ./yalis /opt/tools/bin/
     add-history yalis
@@ -493,8 +493,8 @@ function install_censys() {
 function install_gomapenum() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing GoMapEnum"
-    git -C /opt/tools clone --depth 1 https://github.com/nodauf/GoMapEnum
-    cd /opt/tools/GoMapEnum/src || exit
+    git -C /tmp clone --depth 1 https://github.com/nodauf/GoMapEnum
+    cd /tmp/GoMapEnum/src || exit
     go build .
     mv ./src /opt/tools/bin/gomapenum
     add-history gomapenum

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -109,12 +109,20 @@ function install_amass() {
 function install_ffuf() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing ffuf"
-    git -C /opt/tools clone --depth 1 https://github.com/ffuf/ffuf.git
-    cd /opt/tools/ffuf || exit
-    go build .
-    mv ./ffuf /opt/tools/bin/
-    # https://github.com/ffuf/ffuf/issues/681
-    # go install github.com/ffuf/ffuf/v2@latest
+    if [[ $(uname -m) = 'x86_64' ]]
+    then
+        local arch="amd64"
+
+    elif [[ $(uname -m) = 'aarch64' ]]
+    then
+        local arch="arm64"
+    else
+        criticalecho-noexit "This installation function doesn't support architecture $(uname -m)" && return
+    fi
+    local ffuf_url
+    ffuf_url=$(curl --location --silent "https://api.github.com/repos/ffuf/ffuf/releases/latest" | grep 'browser_download_url.*ffuf.*linux_'"$arch"'.tar.gz"' | grep -o 'https://[^"]*')
+    curl --location -o /tmp/ffuf.tar.gz "$ffuf_url"
+    tar -xf /tmp/ffuf.tar.gz --directory /tmp
     add-history ffuf
     add-test-command "ffuf --help"
     add-to-list "ffuf,https://github.com/ffuf/ffuf,Fast web fuzzer written in Go."

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -829,11 +829,10 @@ function install_sqlmap() {
 function install_sslscan() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing sslscan"
-    git -C /opt/tools clone --depth 1 https://github.com/rbsec/sslscan.git
-    cd /opt/tools/sslscan || exit
+    git -C /tmp clone --depth 1 https://github.com/rbsec/sslscan.git
+    cd /tmp/sslscan || exit
     make static
-    mv /opt/tools/sslscan/sslscan /opt/tools/bin/sslscan
-    make clean
+    mv /tmp/sslscan/sslscan /opt/tools/bin/sslscan
     add-history sslscan
     add-test-command "sslscan --version"
     add-to-list "sslscan,https://github.com/rbsec/sslscan,a tool for testing SSL/TLS encryption on servers"

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -122,7 +122,7 @@ function install_ffuf() {
     local ffuf_url
     ffuf_url=$(curl --location --silent "https://api.github.com/repos/ffuf/ffuf/releases/latest" | grep 'browser_download_url.*ffuf.*linux_'"$arch"'.tar.gz"' | grep -o 'https://[^"]*')
     curl --location -o /tmp/ffuf.tar.gz "$ffuf_url"
-    tar -xf /tmp/ffuf.tar.gz --directory /tmp
+    tar -xf /tmp/ffuf.tar.gz --directory /opt/tools/bin/
     add-history ffuf
     add-test-command "ffuf --help"
     add-to-list "ffuf,https://github.com/ffuf/ffuf,Fast web fuzzer written in Go."

--- a/sources/install/package_wifi.sh
+++ b/sources/install/package_wifi.sh
@@ -97,10 +97,10 @@ function install_hcxtools() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing hcxtools"
     fapt libpcap-dev libcurl4 libcurl4-openssl-dev libssl-dev openssl pkg-config
-    git -C /opt/tools/ clone --depth 1 https://github.com/ZerBea/hcxtools
-    cd /opt/tools/hcxtools || exit
+    git -C /tmp clone --depth 1 https://github.com/ZerBea/hcxtools
+    cd /tmp/hcxtools || exit
     make -j
-    make install PREFIX=/opt/tools clean
+    make install PREFIX=/opt/tools
     add-history hcxtools
     add-test-command "hcxpcapngtool --version"
     add-test-command "hcxhashtool --version"
@@ -111,10 +111,10 @@ function install_hcxdumptool() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing hcxdumptool"
     fapt libpcap-dev libcurl4-openssl-dev
-    git -C /opt/tools/ clone --depth 1 https://github.com/ZerBea/hcxdumptool
-    cd /opt/tools/hcxdumptool || exit
+    git -C /tmp clone --depth 1 https://github.com/ZerBea/hcxdumptool
+    cd /tmp/hcxdumptool || exit
     make -j
-    make install PREFIX=/opt/tools clean
+    make install PREFIX=/opt/tools
     add-history hcxdumptool
     add-test-command "hcxdumptool --version"
     add-to-list "hcxdumptool,https://github.com/ZerBea/hcxdumptool,Small tool to capture packets from wlan devices."


### PR DESCRIPTION
Is there any reason to keep the sslscan build residues? (As sslscan is statically compiled and moved to `/opt/tools/bin`). :rocket: 

```shell
215M	/opt/tools/sslscan
6.7M	/opt/tools/tig
4.4M	/opt/tools/GoMapEnum
1.5M	/opt/tools/hcxdumptool
1.3M	/opt/tools/hcxtools
1.2M	/opt/tools/ffuf
376K	/opt/tools/yalis
```

+ tig installation was creating an empty `/root/bin` folder and a config file in `/root/etc/tigrc`