### PR TITLE
Fixed impacket secretsdump.py KeyError

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -284,7 +284,8 @@ function install_aclpwn() {
 function install_impacket() {
     colorecho "Installing Impacket scripts"
     pipx install --system-site-packages git+https://github.com/ThePorgs/impacket
-    pipx inject impacket chardet
+    # Pycryptodome because: https://github.com/fortra/impacket/issues/1634
+    pipx inject impacket chardet pycryptodome
     cp -v /root/sources/assets/grc/conf.ntlmrelayx /usr/share/grc/conf.ntlmrelayx
     cp -v /root/sources/assets/grc/conf.secretsdump /usr/share/grc/conf.secretsdump
     cp -v /root/sources/assets/grc/conf.getgpppassword /usr/share/grc/conf.getgpppassword


### PR DESCRIPTION
# Description

After issuing the command:
```shell
secretsdump.py SCCM.lab/sccm-account-da:'SCCM_D@-ftw_'@10.2.10.40
```

I was met with an error:
```
[*] Stopping service RemoteRegistry
Exception ignored in: <function Registry.__del__ at 0x7faef466bce0>
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/winregistry.py", line 185, in __del__
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/winregistry.py", line 182, in close
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/examples/secretsdump.py", line 360, in close
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smbconnection.py", line 605, in closeFile
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smb3.py", line 1356, in close
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smb3.py", line 473, in sendSMB
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smb3.py", line 442, in signSMB
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/crypto.py", line 150, in AES_CMAC
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/site-packages/Cryptodome/Cipher/AES.py", line 228, in new
KeyError: 'Cryptodome.Cipher.AES'
Exception ignored in: <function Registry.__del__ at 0x7faef466bce0>
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/winregistry.py", line 185, in __del__
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/winregistry.py", line 182, in close
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/examples/secretsdump.py", line 360, in close
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smbconnection.py", line 605, in closeFile
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smb3.py", line 1356, in close
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smb3.py", line 473, in sendSMB
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/smb3.py", line 442, in signSMB
  File "/root/.local/share/pipx/venvs/impacket/lib/python3.11/site-packages/impacket/crypto.py", line 150, in AES_CMAC
  File "/root/.pyenv/versions/3.11.11/lib/python3.11/site-packages/Cryptodome/Cipher/AES.py", line 228, in new
KeyError: 'Cryptodome.Cipher.AES'
```

It seems to be related to: https://github.com/fortra/impacket/issues/1634

This PR aims to fix that, after injecting `Pycryptodome` the secretsdump now seems to work fine.

# Related issues

N / A

# Point of attention

N / A
