### PR TITLE
Added `sshpass` history

### DIFF
--- a/sources/assets/shells/history.d/sshpass
+++ b/sources/assets/shells/history.d/sshpass
@@ -1,0 +1,1 @@
+sshpass -p "$PASSWORD" ssh -oStrictHostKeyChecking=no "$USER"@"$TARGET"

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -462,6 +462,7 @@ function package_base() {
     # change default shell
     chsh -s /bin/zsh
 
+    add-history sshpass
     add-history dnsutils
     add-history samba
     add-history ssh


### PR DESCRIPTION
# Description

This PR add an history entry for `sshpass`.

# Related issues

N / A

# Point of attention

We can remove the `-oStrictHostKeyChecking=no` if you want but then sshpass might not be working in case the hostkey is not trusted.
