### PR TITLE
Revert "perf: prune useless tools' git"

### DIFF
--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -172,9 +172,6 @@ function post_install() {
     rm -rf /tmp/*
     rm -rf /var/lib/apt/lists/*
 
-    # Tools' git cleanup
-    find /opt/tools -name .git -exec rm -rf {} \;
-
     colorecho "Stop listening processes"
     local listening_processes
     listening_processes=$(ss -lnpt | awk -F"," 'NR>1 {split($2,a,"="); print a[2]}')


### PR DESCRIPTION
Reverts ThePorgs/Exegol-images#483
```
164.2 find: '/opt/tools/uploader/.git': No such file or directory
164.2 find: '/opt/tools/tig/.git': No such file or directory
164.2 find: '/opt/tools/exploitdb/.git': No such file or directory
164.3 find: '/opt/tools/triliumnext/.git': No such file or directory
...
```