### PR TITLE
Replace apply with set + add unset command in exegol-history

### DIFF
--- a/sources/assets/shells/history.d/exegol-history
+++ b/sources/assets/shells/history.d/exegol-history
@@ -10,7 +10,9 @@ exegol-history add hosts --ip '127.0.0.1'
 exh add hosts --ip '127.0.0.1'
 exegol-history show
 exh show
-exegol-history apply creds
-exh apply creds
-exegol-history apply hosts
-exh apply hosts
+exegol-history set creds
+exh set creds
+exegol-history set hosts
+exh set hosts
+exegol-history unset
+exh unset


### PR DESCRIPTION
# Description

I really like exegol-history but since some update on the tool, the history file was not updated ! I replace the apply with set. I add the unset option too.

# Related issues

Nope.

# Point of attention

N/A
