### PR TITLE
perf(ad): remove bloodhound cache (-1Go)

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -194,6 +194,8 @@ function install_bloodhound-ce() {
     git -C "${bloodhoundce_path}" clone --depth 1 --branch "${latestRelease}" "https://github.com/SpecterOps/BloodHound.git" src
     cd "${bloodhoundce_path}/src/" || exit
     catch_and_retry VERSION=v999.999.999 CHECKOUT_HASH="" python3 ./packages/python/beagle/main.py build --verbose --ci
+    # Force remove go and yarn cache that are not stored in standard locations
+    rm -rf "${bloodhoundce_path}/src/cache" "${bloodhoundce_path}/src/.yarn/cache"
 
     ## SharpHound
     local sharphound_url


### PR DESCRIPTION
Useless build cache: -1Go :rocket: 

```
# du -sh /opt/tools/BloodHound-CE/src/cache               
789M	/opt/tools/BloodHound-CE/src/cache
# du -sh /opt/tools/BloodHound-CE/src/.yarn/cache 
194M	/opt/tools/BloodHound-CE/src/.yarn/cache
```
