### PR TITLE
perf: remove go cache (-5.6Go)

### DIFF
--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -163,6 +163,7 @@ function post_install() {
     # Function used to clean up post-install files
     colorecho "Cleaning..."
     updatedb
+    rm -rf /root/.asdf/installs/golang/*/packages/pkg/mod
     rm -rf /root/.bundle/cache
     rm -rf /root/.cache
     rm -rf /root/.cargo/registry

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -308,8 +308,7 @@ function install_gf() {
       echo ''
       echo '# Enable gf autocompletion'
       # FIXME GOPATH not set
-      # shellcheck disable=SC2016
-      echo 'source "$GOPATH"/pkg/mod/github.com/tomnomnom/gf@*/gf-completion.zsh'
+      cat "$GOPATH"/pkg/mod/github.com/tomnomnom/gf@*/gf-completion.zsh
     } >> ~/.zshrc
     cp -r "$(sh -c "go env GOPATH")"/pkg/mod/github.com/tomnomnom/gf@*/examples ~/.gf
     # Add patterns from 1ndianl33t


### PR DESCRIPTION
Useless go cache: -5.6Go 🚀

It could be removed using `go ​clean -modcache` but a `rm -rf` is faster and remove cache for all go versions.
See <https://www.educative.io/answers/what-is-go-clean--modcache>

```
# du -sh /root/.asdf/installs/golang/*/packages/pkg/mod
4.0K	/root/.asdf/installs/golang/1.19/packages/pkg/mod
5.5G	/root/.asdf/installs/golang/1.22.2/packages/pkg/mod
112M	/root/.asdf/installs/golang/1.23.0/packages/pkg/mod
```