### PR TITLE
perf(base): optimize rvm build (-1.9Go)

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -184,7 +184,7 @@ function install_rvm() {
     rvm install ruby-3.1.2  # needed by cewl, pass-station, evil-winrm
     rvm install ruby-3.1.5  # needed metasploit-framework
     rvm get head
-    rvm cleanup sources
+    rvm cleanup all
     gem update
     add-test-command "rvm --version"
 }

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -184,6 +184,7 @@ function install_rvm() {
     rvm install ruby-3.1.2  # needed by cewl, pass-station, evil-winrm
     rvm install ruby-3.1.5  # needed metasploit-framework
     rvm get head
+    rvm cleanup sources
     gem update
     add-test-command "rvm --version"
 }


### PR DESCRIPTION
No need to keep useless rvm sources once installed:

```
[May 24, 2025 - 23:28:05 (CEST)] exegol-test /workspace # du -sh /usr/local/rvm/                             
2.6G	/usr/local/rvm/
[May 24, 2025 - 23:28:09 (CEST)] exegol-test /workspace # rvm cleanup sources
Cleaning up rvm sources
Cleanup done.
[May 24, 2025 - 23:29:37 (CEST)] exegol-test /workspace # du -sh /usr/local/rvm/
739M	/usr/local/rvm/
```