### PR TITLE
chore(forensic): volatility history

### DIFF
--- a/sources/assets/shells/history.d/volatility2
+++ b/sources/assets/shells/history.d/volatility2
@@ -1,2 +1,5 @@
-volatility2 --profile=Win7SP1x86_23418 netscan -f file.dmp
-volatility2 --profile=SomeLinux -f file.dmp linux_netstat
+volatility2 -f memory.dmp imageinfo
+volatility2 -f memory.dmp --profile=Win7SP1x86 pstree
+volatility2 -f memory.dmp --profile=Win7SP1x86 netscan
+volatility2 -f memory.dmp --profile=Win7SP1x86 cmdline
+volatility2 -f memory.dmp --profile=Win7SP1x86 hashdump

--- a/sources/assets/shells/history.d/volatility3
+++ b/sources/assets/shells/history.d/volatility3
@@ -1,15 +1,6 @@
 volatility3 -f memory.dmp windows.info
 volatility3 -f memory.dmp windows.pslist
-volatility3 -f memory.dmp windows.psscan
-volatility3 -f memory.dmp windows.pstree
-volatility3 -f memory.dmp windows.handles --pid $PID
-volatility3 -f memory.dmp windows.dlllist --pid $PID
-volatility3 -f memory.dmp windows.cmdline
 volatility3 -f memory.dmp windows.netscan
-volatility3 -f memory.dmp windows.netstat
-volatility3 -f memory.dmp windows.registry.hivescan
-volatility3 -f memory.dmp windows.registry.hivelist
-volatility3 -f memory.dmp windows.registry.printkey
-volatility3 -f memory.dmp windows.registry.printkey ‑‑key "Software\Microsoft\Windows\CurrentVersion"
-volatility3 -f memory.dmp windows.filescan
+volatility3 -f memory.dmp windows.cmdline
+volatility3 -f memory.dmp windows.dlllist --pid $PID
 volatility3 -f memory.dmp windows.malfind


### PR DESCRIPTION
I think it is useless to have that much commands in history, only the most used one because you can quickly find what you need using `--help`