### PR TITLE
Add a Firefox extension

### DIFF
--- a/sources/assets/firefox/generate_policy.py
+++ b/sources/assets/firefox/generate_policy.py
@@ -20,7 +20,8 @@ names = [
     "uaswitcher",
     "cookie-editor",
     "wappalyzer",
-    "multi-account-containers"
+    "multi-account-containers",
+    "multi-url-opener"
 ]
 
 def get_extension_id(extension_name):


### PR DESCRIPTION
Add a Firefox extension that enables users to quickly open a predefined list of URLs.

Use Cases:
- Penetration testing or bug bounty engagements with multiple in-scope URLs
- Certification exams involving web-based targets

This tool streamlines the workflow by reducing the time and effort required to open multiple URLs manually.