### PR TITLE
feat: added argcomplete script for netexec

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -1278,6 +1278,7 @@ function install_netexec() {
     mkdir -p ~/.nxc
     [[ -f ~/.nxc/nxc.conf ]] && mv ~/.nxc/nxc.conf ~/.nxc/nxc.conf.bak
     cp -v /root/sources/assets/netexec/nxc.conf ~/.nxc/nxc.conf
+    register-python-argcomplete nxc >> ~/.zshrc
     add-aliases netexec
     add-history netexec
     add-test-command "netexec --help"


### PR DESCRIPTION
# Description

This PR adds the `netexec` argcomplete script. (https://www.netexec.wiki/getting-started/installation/setting-up-tab-completion#setting-up-tab-completion)

# Related issues

N / A

# Point of attention

N / A
