### PR TITLE
fix: fixed bh-ce install

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -280,7 +280,7 @@ function install_bloodhound-ce() {
     cp -v /root/sources/assets/bloodhound-ce/bloodhound.config.json "${bloodhoundce_path}"
 
     # the following test command probably needs to be changed. No idea how we can make sure bloodhound-ce works as intended.
-    add-test-command "${bloodhoundce_path}/bloodhound -version"
+    add-test-command "${bloodhoundce_path}bloodhound --version"
     add-test-command "service postgresql start && sleep 5 && PGPASSWORD=exegol4thewin psql -U bloodhound -d bloodhound -h localhost -c '\l' && service postgresql stop"
     add-to-list "BloodHound-CE,https://github.com/SpecterOps/BloodHound,Active Directory security tool for reconnaissance and attacking AD environments (Community Edition)"
 }

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -271,7 +271,6 @@ function install_bloodhound-ce() {
     # Files and directories
     # work directory required by bloodhound
     mkdir -p "${bloodhoundce_path}/work"
-    ln -v -s "${bloodhoundce_path}/src/artifacts/bhapi" "${bloodhoundce_path}/bloodhound"
     cp -v /root/sources/assets/bloodhound-ce/bloodhound-ce /opt/tools/bin/
     cp -v /root/sources/assets/bloodhound-ce/bloodhound-ce-reset /opt/tools/bin/
     cp -v /root/sources/assets/bloodhound-ce/bloodhound-ce-stop /opt/tools/bin/

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -193,7 +193,27 @@ function install_bloodhound-ce() {
     latestRelease=$(jq --raw-output 'first(.[] | select(.tag_name | contains("-rc") | not) | .tag_name)' "${curl_tempfile}")
     git -C "${bloodhoundce_path}" clone --depth 1 --branch "${latestRelease}" "https://github.com/SpecterOps/BloodHound.git" src
     cd "${bloodhoundce_path}/src/" || exit
-    catch_and_retry /bin/sh -c 'VERSION=v999.999.999 CHECKOUT_HASH="" python3 ./packages/python/beagle/main.py build --verbose --ci'
+
+    # Reference: https://github.com/SpecterOps/BloodHound/blob/main/dockerfiles/bloodhound.Dockerfile
+    # Build the UI
+    yarn install
+    yarn build
+    mkdir -p ./cmd/api/src/api/static/assets
+    cp -r ./cmd/ui/dist/. ./cmd/api/src/api/static/assets
+
+    # Build the API
+    git --no-pager -c 'versionsort.suffix=-rc' tag --list v*.*.* --sort=-v:refname | head -n 1 | sed 's/^v//' | awk \
+    -F'[.+-]' \
+    -v pkg="github.com/specterops/bloodhound/cmd/api/src/version" \
+    '{ major = $1; minor = $2; patch = $3; pre = ""; if ($4) pre = $4; \
+    printf("-X '\''%s.majorVersion=%s'\'' ", pkg, major); \
+    printf("-X '\''%s.minorVersion=%s'\'' ", pkg, minor); \
+    printf("-X '\''%s.patchVersion=%s'\''", pkg, patch); \
+    if (pre != "") \
+      printf(" -X '\''%s.prereleaseVersion=%s'\''", pkg, pre); \
+    }' > LDFLAGS
+    go build -C cmd/api/src -o ${bloodhoundce_path}/bloodhound -ldflags "$(cat LDFLAGS)" github.com/specterops/bloodhound/cmd/api/src/cmd/bhapi
+
     # Force remove go and yarn cache that are not stored in standard locations
     rm -rf "${bloodhoundce_path}/src/cache" "${bloodhoundce_path}/src/.yarn/cache"
 

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -202,17 +202,7 @@ function install_bloodhound-ce() {
     cp -r ./cmd/ui/dist/. ./cmd/api/src/api/static/assets
 
     # Build the API
-    git --no-pager -c 'versionsort.suffix=-rc' tag --list v*.*.* --sort=-v:refname | head -n 1 | sed 's/^v//' | awk \
-    -F'[.+-]' \
-    -v pkg="github.com/specterops/bloodhound/cmd/api/src/version" \
-    '{ major = $1; minor = $2; patch = $3; pre = ""; if ($4) pre = $4; \
-    printf("-X '\''%s.majorVersion=%s'\'' ", pkg, major); \
-    printf("-X '\''%s.minorVersion=%s'\'' ", pkg, minor); \
-    printf("-X '\''%s.patchVersion=%s'\''", pkg, patch); \
-    if (pre != "") \
-      printf(" -X '\''%s.prereleaseVersion=%s'\''", pkg, pre); \
-    }' > LDFLAGS
-    go build -C cmd/api/src -o ${bloodhoundce_path}/bloodhound -ldflags "$(cat LDFLAGS)" github.com/specterops/bloodhound/cmd/api/src/cmd/bhapi
+    go build -C cmd/api/src -o ${bloodhoundce_path}/bloodhound -ldflags "-X 'github.com/specterops/bloodhound/cmd/api/src/version.majorVersion=8' -X 'github.com/specterops/bloodhound/cmd/api/src/version.minorVersion=0' -X 'github.com/specterops/bloodhound/cmd/api/src/version.patchVersion=1'" github.com/specterops/bloodhound/cmd/api/src/cmd/bhapi
 
     # Force remove go and yarn cache that are not stored in standard locations
     rm -rf "${bloodhoundce_path}/src/cache" "${bloodhoundce_path}/src/.yarn/cache"


### PR DESCRIPTION
# Description

This PR aim to fix the BH-CE install that currently throw an error duing the build:
```
2025-07-31T15:04:22.1237970Z #18 ERROR: process "/bin/sh -c ./entrypoint.sh package_ad" did not complete successfully: exit code: 1
2025-07-31T15:04:22.2357590Z ------
2025-07-31T15:04:22.2362680Z  > [14/29] RUN ./entrypoint.sh package_ad:
2025-07-31T15:04:22.2363370Z 1428.4     project_ctx = new_project_context(
2025-07-31T15:04:22.2363860Z 1428.4                   ^^^^^^^^^^^^^^^^^^^^
2025-07-31T15:04:22.2364790Z 1428.4   File "/opt/tools/BloodHound-CE/src/packages/python/beagle/beagle/project/project.py", line 265, in new_project_context
2025-07-31T15:04:22.2365800Z 1428.4     project_root = _find_project_root(foss_only=foss_only)
2025-07-31T15:04:22.2366400Z 1428.4                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-07-31T15:04:22.2367320Z 1428.4   File "/opt/tools/BloodHound-CE/src/packages/python/beagle/beagle/project/project.py", line 85, in _find_project_root
2025-07-31T15:04:22.2370180Z 1428.4     raise WorkspaceException(f"Unable to find project root. Started searching from {file_dir}.")
2025-07-31T15:04:22.2371600Z 1428.4 beagle.project.project.WorkspaceException: Unable to find project root. Started searching from /opt/tools/BloodHound-CE/src/packages/python/beagle/beagle/project.
```

I tested the install and it seems fine, I was able to ingest some data.

# Related issues

N / A

# Point of attention

N / A
