### PR TITLE
fix: chainsaw install

### DIFF
--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -111,7 +111,10 @@ function install_chainsaw() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing chainsaw"
     source "$HOME/.cargo/env"
-    cargo install chainsaw
+    git -C /opt/tools/ clone --depth 1 https://github.com/WithSecureLabs/chainsaw.git
+    cd /opt/tools/chainsaw || exit
+    cargo build --release
+    ln -v -s /opt/tools/chainsaw/target/release/chainsaw /opt/tools/bin/chainsaw
     add-history chainsaw
     add-test-command "chainsaw --help"
     add-to-list "chainsaw,https://github.com/WithSecureLabs/chainsaw,Rapidly Search and Hunt through Windows Forensic Artefacts"


### PR DESCRIPTION
# Description

A user reported on the Discord server that the `chainsaw` installed was not the IR software from https://github.com/WithSecureLabs/chainsaw. This PR aims to fix that. It seems the package actually installed is this one: https://crates.io/crates/chainsaw:
```sh
$ chainsaw --help

chainsaw 1.14.3
A tool to manipulate newick trees
```

# Related issues

N / A

# Point of attention

Also, the tool normally need two external resources to work correctly:
```sh
git clone https://github.com/SigmaHQ/sigma
git clone https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES.git
```

Where should we put theses resources ? In Exegol-resources maybe ?