### PR TITLE
Fix openvpn ungraceful disconnect

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -467,6 +467,15 @@ function install_openvpn() {
   ((LINE++))
   sed -i "${LINE}"'i rm /etc/resolv.conf.backup' /etc/openvpn/update-resolv-conf
 
+  LINE=$(($(grep -n 'down)' /etc/openvpn/update-resolv-conf | cut -d ':' -f1) +1))
+  sed -i "${LINE}"'i cp /etc/resolv.conf /etc/resolv.conf.backup' /etc/openvpn/update-resolv-conf
+
+  LINE=$(($(grep -n 'resolvconf -d' /etc/openvpn/update-resolv-conf | cut -d ':' -f1) +1))
+  # shellcheck disable=SC2016
+  sed -i "${LINE}"'i [ "$((resolvconf -l "tun*" 2>/dev/null || resolvconf -l "tap*") | grep -vE "^(\s*|#.*)$")" ] && /sbin/resolvconf -u || cp /etc/resolv.conf.backup /etc/resolv.conf' /etc/openvpn/update-resolv-conf
+  ((LINE++))
+  sed -i "${LINE}"'i rm /etc/resolv.conf.backup' /etc/openvpn/update-resolv-conf
+
   add-test-command "openvpn --version"
   add-to-list "OpenVPN,https://openvpn.net/,Fast and Easy Zero-Trust VPN Fully in Your Control"
 }


### PR DESCRIPTION
# Description

This fix an issue occurring when `openvpn` was closed ungracefully.

The file `/etc/resolv.conf` wasn't took in backup and restored when the `down /etc/openvpn/update-resolv-conf` script was executed.

The result was an empty `/etc/resolv.conf`file.


# Related issues

To reproduce current issue.

```
exegol start <name> <image> --vpn ''
openvpn <file>.ovpn
CTRL-C
```
The file `/etc/resolv.conf` will be empty.