### PR TITLE
Build ruler from source to prevent dependency errors

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -350,12 +350,27 @@ function install_privexchange() {
 }
 
 function install_ruler() {
-    colorecho "Downloading ruler and form templates"
+    colorecho "Downloading ruler and form templates from source..."
     mkdir -p /opt/tools/ruler || exit
     cd /opt/tools/ruler || exit
     asdf set golang 1.23.0
     mkdir -p .go/bin
-    GOBIN=/opt/tools/ruler/.go/bin go install -v github.com/sensepost/ruler@latest
+    git clone https://github.com/sensepost/ruler.git src
+
+    # Check if cloning was successful before proceeding
+    if [ ! -d "src" ]; then
+        colorecho "ERROR: Failed to clone the ruler repository." "red"
+        exit 1
+    fi
+
+    # Navigate into the source directory
+    cd src || exit
+
+    # Install from source.
+    GOBIN=/opt/tools/ruler/.go/bin go install .
+    cd ..
+    rm -rf src
+
     asdf reshim golang
     add-aliases ruler
     add-history ruler


### PR DESCRIPTION
fix(build): Build ruler from source to prevent dependency errors

The previous `go install ...@latest` command was causing build failures due to updated upstream dependencies. Building directly from a cloned source ensures the project's `go.mod` is used, resolving the issue.

# Description

> A description of your PR, what it brings or corrects. Don't forget to configure your PR to the dev branch (cf. https://exegol.readthedocs.io/en/latest/community/contributors.html)

# Related issues

> If your PR responds to an issue for a bug fix or feature request, make sure to includes references to the issues (e.g. "fixes #xxxx").

# Point of attention

> Things you are not sure about that deserve special attention if you have doubts or questions.
