### PR TITLE
Fix Weevely3 install

### DIFF
--- a/sources/assets/shells/aliases.d/weevely
+++ b/sources/assets/shells/aliases.d/weevely
@@ -1,1 +1,0 @@
-alias weevely.py="/opt/tools/weevely3/venv/bin/python3 /opt/tools/weevely3/weevely.py"

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -26,7 +26,7 @@ function install_weevely() {
     pipx install --python 3.13 --system-site-packages git+https://github.com/epinna/weevely3
     add-aliases weevely
     add-history weevely
-    add-test-command "weevely.py --help"
+    add-test-command "weevely --help"
     add-to-list "weevely,https://github.com/epinna/weevely3,a webshell designed for post-exploitation purposes that can be extended over the network at runtime."
 }
 

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -23,12 +23,7 @@ function install_web_apt_tools() {
 
 function install_weevely() {
     colorecho "Installing weevely"
-    git -C /opt/tools clone --depth 1 https://github.com/epinna/weevely3
-    cd /opt/tools/weevely3 || exit
-    python3 -m venv --system-site-packages ./venv
-    source ./venv/bin/activate
-    pip3 install -r requirements.txt
-    deactivate
+    pipx install --python 3.13 --system-site-packages git+https://github.com/epinna/weevely3
     add-aliases weevely
     add-history weevely
     add-test-command "weevely.py --help"

--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -22,9 +22,9 @@ function install_web_apt_tools() {
 }
 
 function install_weevely() {
+    # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing weevely"
     pipx install --python 3.13 --system-site-packages git+https://github.com/epinna/weevely3
-    add-aliases weevely
     add-history weevely
     add-test-command "weevely --help"
     add-to-list "weevely,https://github.com/epinna/weevely3,a webshell designed for post-exploitation purposes that can be extended over the network at runtime."


### PR DESCRIPTION
# Description

Weevely have changed the install method (they delete the requirement.txt file and use UV / pipx instead). This PR fix the install.

# Related issues

N/A

# Point of attention

TIL that you can specify a Python version with pipx ! Pretty convenient !