### PR TITLE
fix: fixed shuffledns tool + history

### DIFF
--- a/sources/assets/shells/history.d/massdns
+++ b/sources/assets/shells/history.d/massdns
@@ -1,0 +1,1 @@
+massdns -r resolvers.txt -t AAAA domains.txt

--- a/sources/assets/shells/history.d/shuffledns
+++ b/sources/assets/shells/history.d/shuffledns
@@ -1,4 +1,4 @@
-shuffledns -d "$DOMAIN" -list example-subdomains.txt -r resolvers.txt
-subfinder -d "$DOMAIN" | shuffledns -d "$DOMAIN" -r resolvers.txt
-shuffledns -d "$DOMAIN" -w wordlist.txt -r resolvers.txt
-echo "$DOMAIN" | shuffledns -w wordlist.txt -r resolvers.txt
+shuffledns -d "$DOMAIN" -list example-subdomains.txt -r resolvers.txt -mode resolve
+subfinder -d "$DOMAIN" | shuffledns -d "$DOMAIN" -r resolvers.txt -mode resolve
+shuffledns -d "$DOMAIN" -w `fzf-wordlists` -r resolvers.txt -mode bruteforce
+echo "$DOMAIN" | shuffledns -w `fzf-wordlists` -r resolvers.txt -mode bruteforce

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -227,6 +227,18 @@ function install_dnsx() {
     add-to-list "dnsx,https://github.com/projectdiscovery/dnsx,A tool for DNS reconnaissance that can help identify subdomains and other related domains."
 }
 
+function install_massdns() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing massdns"
+    git -C /opt/tools clone --depth 1 https://github.com/blechschmidt/massdns.git
+    cd /opt/tools/massdns || exit
+    make
+    ln -s /opt/tools/massdns/bin/massdns /usr/bin/massdns
+    add-history massdns
+    add-test-command "massdns --help"
+    add-to-list "massdns,https://github.com/blechschmidt/massdns,MassDNS is a simple high-performance DNS stub resolver targeting those who seek to resolve a massive amount of domain names in the order of millions or even billions."
+}
+
 function install_shuffledns() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing shuffledns"

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -331,6 +331,7 @@ function package_network() {
     install_fierce
     # install_odat                  # Oracle Database Attacking Tool, FIXME
     install_dnsx                    # Fast and multi-purpose DNS toolkit
+    install_massdns                 # Install massdns as a requirement for shuffledns
     install_shuffledns              # Wrapper around massdns to enumerate valid subdomains
     install_tailscale               # Zero config VPN for building secure networks
     install_ligolo-ng               # Tunneling tool that uses a TUN interface

--- a/sources/install/package_network.sh
+++ b/sources/install/package_network.sh
@@ -233,7 +233,7 @@ function install_massdns() {
     git -C /opt/tools clone --depth 1 https://github.com/blechschmidt/massdns.git
     cd /opt/tools/massdns || exit
     make
-    ln -s /opt/tools/massdns/bin/massdns /usr/bin/massdns
+    ln -s /opt/tools/massdns/bin/massdns /opt/tools/bin/massdns
     add-history massdns
     add-test-command "massdns --help"
     add-to-list "massdns,https://github.com/blechschmidt/massdns,MassDNS is a simple high-performance DNS stub resolver targeting those who seek to resolve a massive amount of domain names in the order of millions or even billions."


### PR DESCRIPTION
Greetings,

# Description

This PR aims to fix the `shuffledns` tool from Projectdicovery, right now the tool output:
```
[INF] Current shuffledns version v1.1.0 (latest)
[FTL] Could not create runner: could not find massdns binary
```

The binary `massdns` is required (https://github.com/blechschmidt/massdns), also `shuffledns` now take a `--resolve` parameter that wasn't in the current history.

# Related issues
N/A

# Point of attention
N/A

Regards.