### PR TITLE
Fix wpscan history

### DIFF
--- a/sources/assets/shells/history.d/wpscan
+++ b/sources/assets/shells/history.d/wpscan
@@ -1,3 +1,3 @@
-wpscan --api-token APITOKEN --url "http://$TARGET/" --no-banner --enumerate u1-20
-wpscan --api-token APITOKEN --url "http://$TARGET/" --no-banner --plugins-detection aggressive
-wpscan --api-token APITOKEN --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P /usr/share/seclists/Passwords/darkweb2017-top1000.txt
+wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --enumerate u1-20
+wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-detection aggressive
+wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P /usr/share/seclists/Passwords/darkweb2017-top1000.txt

--- a/sources/assets/shells/history.d/wpscan
+++ b/sources/assets/shells/history.d/wpscan
@@ -1,3 +1,3 @@
 wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --enumerate u1-20
 wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-detection aggressive
-wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P /usr/share/seclists/Passwords/darkweb2017-top1000.txt
+wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`

--- a/sources/assets/shells/history.d/wpscan
+++ b/sources/assets/shells/history.d/wpscan
@@ -1,3 +1,3 @@
-wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --enumerate u1-20
-wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-detection aggressive
-wpscan --api-token ${WPSCAN_API_TOKEN} --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`
+wpscan --api-token $WPSCAN_API_TOKEN --url "http://$TARGET/" --no-banner --enumerate u1-20
+wpscan --api-token $WPSCAN_API_TOKEN --url "http://$TARGET/" --no-banner --plugins-detection aggressive
+wpscan --api-token $WPSCAN_API_TOKEN --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`

--- a/sources/assets/shells/history.d/wpscan
+++ b/sources/assets/shells/history.d/wpscan
@@ -1,3 +1,3 @@
-wpscan --api-token $WPSCAN_API_TOKEN --url "http://$TARGET/" --no-banner --enumerate u1-20
-wpscan --api-token $WPSCAN_API_TOKEN --url "http://$TARGET/" --no-banner --plugins-detection aggressive
-wpscan --api-token $WPSCAN_API_TOKEN --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`
+wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --enumerate u1-20
+wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --plugins-detection aggressive
+wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`


### PR DESCRIPTION
# Description
Greetings,

Since version 3.7.10, `wpscan` make use of the **WPSCAN_API_TOKEN** env variable: https://github.com/wpscanteam/wpscan?tab=readme-ov-file#load-api-token-from-env-since-v3710.

Regards.

# Related issues

N / A

# Point of attention

N / A
