### PR TITLE
chore(web): improve wpscan history

### DIFF
--- a/sources/assets/shells/history.d/wpscan
+++ b/sources/assets/shells/history.d/wpscan
@@ -1,3 +1,3 @@
-wpscan --api-token APITOKEN --url "http://$TARGET/" --no-banner --enumerate u1-20
-wpscan --api-token APITOKEN --url "http://$TARGET/" --no-banner --plugins-detection aggressive
-wpscan --api-token APITOKEN --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P /usr/share/seclists/Passwords/darkweb2017-top1000.txt
+wpscan --url "http://$TARGET/" --no-banner --enumerate u1-20
+wpscan --url "http://$TARGET/" --no-banner --plugins-detection aggressive
+wpscan --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`


### PR DESCRIPTION
`/usr/share/seclists/Passwords/darkweb2017-top1000.txt` does not exists + no one have wpscan API tokens, so lets make it simple and fast :)