### PR TITLE
chore: bump binwalk to v3

### DIFF
--- a/sources/assets/shells/aliases.d/binwalk
+++ b/sources/assets/shells/aliases.d/binwalk
@@ -1,1 +1,0 @@
-alias binwalk='binwalk --run-as=root'

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -30,7 +30,7 @@ function install_binwalk() {
     colorecho "Installing binwalk"
     cargo install binwalk
     fapt squashfs-tools
-    pipx install jefferson ubi-reader uefi_firmware
+    pipx install --system-site-packages jefferson ubi-reader uefi_firmware
     add-history binwalk
     add-test-command "binwalk --help"
     add-to-list "binwalk,https://github.com/ReFirmLabs/binwalk,Binwalk is a tool for analyzing / reverse engineering / and extracting firmware images."

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -26,9 +26,11 @@ function install_forensic_apt_tools() {
 }
 
 function install_binwalk() {
+    # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing binwalk"
-    fapt squashfs-tools binwalk
-    add-aliases binwalk
+    cargo install binwalk
+    fapt squashfs-tools
+    pipx install jefferson ubi-reader uefi_firmware
     add-history binwalk
     add-test-command "binwalk --help"
     add-to-list "binwalk,https://github.com/ReFirmLabs/binwalk,Binwalk is a tool for analyzing / reverse engineering / and extracting firmware images."


### PR DESCRIPTION
# Description

Binwalk was totally rewritten in Rust, I also installed additionnal dependency sometimes required by Binwalk (c.f: https://github.com/ReFirmLabs/binwalk/tree/master/dependencies).

# Related issues

N/A

# Point of attention

N/A
