### PR TITLE
fix: smtp-user-enum history

### DIFF
--- a/sources/assets/shells/history.d/smtp-user-enum
+++ b/sources/assets/shells/history.d/smtp-user-enum
@@ -1,3 +1,3 @@
-smtp-user-enum -M EXPN -U /usr/share/seclists/Usernames/top-usernames-shortlist.txt -t "$TARGET" "$PORT"
-smtp-user-enum -M RCPT -U /usr/share/seclists/Usernames/top-usernames-shortlist.txt -t "$TARGET" "$PORT"
-smtp-user-enum -M VRFY -U /usr/share/seclists/Usernames/top-usernames-shortlist.txt -t "$TARGET" "$PORT"
+smtp-user-enum -U `fzf-wordlists` "$TARGET" "$PORT"
+smtp-user-enum -m EXPN -U `fzf-wordlists` "$TARGET" "$PORT"
+smtp-user-enum -m RCPT -U `fzf-wordlists` "$TARGET" "$PORT"


### PR DESCRIPTION
`smtp-user-enum` commands in history don't work at all + VRFY is the default option :D