### PR TITLE
chore(ad): add kerberos auth evil-winrm history

### DIFF
--- a/sources/assets/shells/history.d/evil-winrm
+++ b/sources/assets/shells/history.d/evil-winrm
@@ -1,3 +1,3 @@
-evil-winrm -r "$DOMAIN" -i "$TARGET"
+KRB5CCNAME="ticket.ccache" evil-winrm -r "$DOMAIN" -i "$TARGET"
 evil-winrm -u "$USER" -H "$NT_HASH" -i "$TARGET"
 evil-winrm -u "$USER" -p "$PASSWORD" -i "$TARGET"

--- a/sources/assets/shells/history.d/evil-winrm-py
+++ b/sources/assets/shells/history.d/evil-winrm-py
@@ -2,3 +2,4 @@ evil-winrm-py --ip "$TARGET" --user "$USER" --password "$PASSWORD"
 evil-winrm-py --ip "$TARGET" --user "$USER" --password "$PASSWORD" --kerberos
 evil-winrm-py --ip "$TARGET" --user "$USER" --hash "$NT_HASH"
 evil-winrm-py --ip "$TARGET" --user "$USER" --kerberos --no-pass
+KRB5CCNAME="ticket.ccache" evil-winrm-py --ip "$TARGET" --kerberos


### PR DESCRIPTION
I think it could be really usefull to add `KRB5CCNAME="ticket.ccache"` behind all commands requiring kerberos auth :)