### PR TITLE
Update netexec history

### DIFF
--- a/sources/assets/shells/history.d/netexec
+++ b/sources/assets/shells/history.d/netexec
@@ -8,17 +8,19 @@ netexec smb "$TARGET" --continue-on-success -u users.txt -p passwords.txt
 netexec smb "$TARGET" --local-auth -u "$USER" -H "$NT_HASH" -M enum_avproducts
 netexec smb "$TARGET" --local-auth -u "$USER" -H "$NT_HASH" -M mimikatz
 netexec smb "$TARGET" -u '' -p '' --pass-pol
-netexec smb 192.168.56.0/24 --gen-relay-list smb_targets.txt
-netexec smb 192.168.56.0/24 --local-auth -u '' -p ''
-netexec smb 192.168.56.0/24 -u "$USER" -p "$PASSWORD" --loggedon-users
-netexec smb 192.168.56.0/24 -u "$USER" -p "$PASSWORD" --sessions
-netexec smb 192.168.56.0/24 -u "$USER" -p "$PASSWORD" --shares
-netexec smb 192.168.56.0/24 -u '' -p '' --shares
+netexec smb "$IP/24" --gen-relay-list smb_targets.txt
+netexec smb "$IP/24" --local-auth -u '' -p ''
+netexec smb "$IP/24" -u "$USER" -p "$PASSWORD" --loggedon-users
+netexec smb "$IP/24" -u "$USER" -p "$PASSWORD" --sessions
+netexec smb "$IP/24" -u "$USER" -p "$PASSWORD" --shares
+netexec smb "$IP/24" -u '' -p '' --shares
 netexec smb "$IP" -u "$USER" -p "$PASSWORD" -M noPac
 netexec smb "$IP" -u "$USER" -p "$PASSWORD" -M petitpotam
 netexec smb "$IP" -u '' -p '' -M zerologon
 netexec smb "$IP" -u '' -p '' -M ms17-010
 netexec smb "$IP" -u '' -p '' -M ioxidresolver
+nxc smb "$IP" -u "$USER" -p "$PASSWORD" --shares
+netexec smb "$IP" -u '' -p '' --generate-hosts-file hosts
 netexec smb --list-modules
 nxc ldap "$DC_HOST" -d "$DOMAIN" -u "$USER" -p "$PASSWORD" -M maq
 nxc ldap "$DC_HOST" -d "$DOMAIN" -u "$USER" -p "$PASSWORD"
@@ -29,15 +31,16 @@ nxc smb "$TARGET" --continue-on-success -u users.txt -p passwords.txt
 nxc smb "$TARGET" --local-auth -u "$USER" -H "$NT_HASH" -M enum_avproducts
 nxc smb "$TARGET" --local-auth -u "$USER" -H "$NT_HASH" -M mimikatz
 nxc smb "$TARGET" -u '' -p '' --pass-pol
-nxc smb 192.168.56.0/24 --gen-relay-list smb_targets.txt
-nxc smb 192.168.56.0/24 --local-auth -u '' -p ''
-nxc smb 192.168.56.0/24 -u "$USER" -p "$PASSWORD" --loggedon-users
-nxc smb 192.168.56.0/24 -u "$USER" -p "$PASSWORD" --sessions
-nxc smb 192.168.56.0/24 -u "$USER" -p "$PASSWORD" --shares
-nxc smb 192.168.56.0/24 -u '' -p '' --shares
+nxc smb "$IP/24" --gen-relay-list smb_targets.txt
+nxc smb "$IP/24" --local-auth -u '' -p ''
+nxc smb "$IP/24" -u "$USER" -p "$PASSWORD" --loggedon-users
+nxc smb "$IP/24" -u "$USER" -p "$PASSWORD" --sessions
+nxc smb "$IP/24" -u "$USER" -p "$PASSWORD" --shares
+nxc smb "$IP/24" -u '' -p '' --shares
 nxc smb "$IP" -u "$USER" -p "$PASSWORD" -M noPac
 nxc smb "$IP" -u "$USER" -p "$PASSWORD" -M petitpotam
 nxc smb "$IP" -u '' -p '' -M zerologon
 nxc smb "$IP" -u '' -p '' -M ms17-010
 nxc smb "$IP" -u '' -p '' -M ioxidresolver
-
+nxc smb "$IP" -u "$USER" -p "$PASSWORD" --shares
+nxc smb "$IP" -u '' -p '' --generate-hosts-file hosts


### PR DESCRIPTION
# Description
Proposed update for the netexec history file, with the following changes: 
1) Changed the 192.168.56.0/24 range by "$IP/24", as the added variable $IP in exegol history is more likely to be used as is than a private IP range, which can always be added afterwards 
2) Added the "--shares" option in second position in the history as it is one of the most used option when engaging a CTF or a pentest 
3) Added the "--generate-hosts-file" option as the last history command, and therefore the first the user will see, as it is more likely to be of use than the "ioxidresolver" module that we currently have as the first netexec option.
