### PR TITLE
chore: image size optimization (-500Mo)

### DIFF
--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -182,8 +182,8 @@ function post_install() {
     rm -rf /tmp/*
     rm -rf /var/lib/apt/lists/*
 
-    # debconf cache (safe)
-    rm -f /var/cache/debconf/templates.dat /var/cache/debconf/config.dat
+    # debconf cache
+    rm -f /var/cache/debconf
 
     colorecho "Stop listening processes"
     local listening_processes

--- a/sources/install/common.sh
+++ b/sources/install/common.sh
@@ -167,16 +167,23 @@ function fix_ownership() {
 function post_install() {
     # Function used to clean up post-install files
     colorecho "Cleaning..."
-    updatedb
+
+    # language/tool caches
     rm -rf /root/.asdf/installs/golang/*/packages/pkg/mod
     rm -rf /root/.bundle/cache
     rm -rf /root/.cache
     rm -rf /root/.cargo/registry
     rm -rf /root/.gradle/caches
+    rm -rf /root/.local/state/pipx/log
     rm -rf /root/.npm/_cacache
     rm -rf /root/.nvm/.cache
+
+    # temp + apt
     rm -rf /tmp/*
     rm -rf /var/lib/apt/lists/*
+
+    # debconf cache (safe)
+    rm -f /var/cache/debconf/templates.dat /var/cache/debconf/config.dat
 
     colorecho "Stop listening processes"
     local listening_processes
@@ -194,13 +201,19 @@ function post_build() {
     colorecho "Post build..."
     rm -rfv /root/sources
     add-test-command "if [[ $(sudo ss -lnpt | tail -n +2 | wc -l) -ne 0 ]]; then ss -lnpt && false;fi"
+
+    colorecho "Build database for locate command"
+    updatedb
+
     colorecho "Sorting tools list"
     (head -n 1 /.exegol/installed_tools.csv && tail -n +2 /.exegol/installed_tools.csv | sort -f ) | tee /tmp/installed_tools.csv.sorted
     mv /tmp/installed_tools.csv.sorted /.exegol/installed_tools.csv
+
     colorecho "Adding end-of-preset in zsh_history"
     echo "# -=-=-=-=-=-=-=- YOUR COMMANDS BELOW -=-=-=-=-=-=-=- #" >> /opt/.exegol_history
     cp /opt/.exegol_history ~/.zsh_history
     cp /opt/.exegol_history ~/.bash_history
+
     colorecho "Removing desktop icons"
     if [ -d "/root/Desktop" ]; then rm -r /root/Desktop; fi
 }


### PR DESCRIPTION
Here a dive summary of the latest nightly exegol image
```
│ Image Details ├──────────────────────────────────────────────────────────────────                                                                                 
                                                                                                                                                                                         
Image name: d498ba83c5b4                                                                                                                                                                 
Total Image size: 47 GB                                                                                                                                                                  
Potential wasted space: 776 MB                                                                                                                                                           
Image efficiency score: 98 %                                                                                                                                                             
                                                                                                                                                                                         
Count   Total Space  Path                                                                                                                                                                
   22        455 MB  /var/lib/plocate/plocate.db                                                                                                                                         
    2         73 MB  /boot/initrd.img-6.1.0-41-rt-amd64                                                                                                                                  
   21         37 MB  /var/cache/debconf/templates.dat                                                                                                                                    
    2         34 MB  /var/lib/postgresql/15/main/pg_wal/000000010000000000000001                                                                                                         
   21         30 MB  /var/lib/dpkg/status
```

- `/var/lib/plocate/plocate.db` is regenerated each time on the `post_install`, this is absolutely useless as it is only used by `[pm]locate` commands, we can move it to the `post_build` step and save ~400Mo over each layers.
- `/boot/*` (initrd/vmlinuz/etc.): kernel artifacts are unnecessary in containers (containers don’t boot their own kernel), but I may confirm with the team before removing those artifacts
- `/var/cache/debconf/*` is package configuration metadata and is automatically recreated if needed, useless to keep it updated between each layers
- `/var/lib/dpkg/status` is dpkg database; must keep (removing breaks apt/dpkg).
- `/var/lib/postgresql/15/main/pg_wal/...` are postgres data, we have to keep it
- Additional cleanup: `/root/.local/state/pipx/log`: pipx logs, we can get rid of them