### PR TITLE
chore: prevent `.wget-hsts` creation during install (-0.5Ko)

### DIFF
--- a/sources/assets/shells/wgetrc
+++ b/sources/assets/shells/wgetrc
@@ -1,3 +1,5 @@
 # Wget config only used in build stage (defined in common.sh)
 # The following option prevent wget from generating too much output
 progress=dot:mega
+# Disable ~/.wget-hsts file creation
+hsts=off


### PR DESCRIPTION
Prevent useless `.wget-hsts` build leftover

```console
# ll /root/.wget-hsts  
-rw-r--r-- 1 root root 631 Dec 10 11:05 /root/.wget-hsts
# cat /root/.wget-hsts
# HSTS 1.0 Known Hosts database for GNU Wget.
# Edit at your own risk.
# <hostname>	<port>	<incl. subdomains>	<created>	<max-age>
gitlab.com	0	0	1765320100	31536000
bin.equinox.io	0	1	1765319434	31536000
wordlists-cdn.assetnote.io	0	1	1765320733	63072000
bitbucket.org	0	1	1765322889	63072000
raw.githubusercontent.com	0	0	1765324975	31536000
out7.hex-rays.com	0	0	1765325076	31536000
dot.net	0	0	1765319504	31536000
portswigger.net	0	0	1765321367	31536000
packages.microsoft.com	0	1	1765319497	31536000
debian.neo4j.com	0	1	1765322314	63072000
github.com	0	1	1765325101	31536000
gist.githubusercontent.com	0	0	1765321828	31536000
```