### PR TITLE
chore: remove leftover JDK source archives (-100Mo)

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -569,6 +569,7 @@ function package_base() {
     ln -s -v /usr/lib/jvm/java-17-openjdk-* /usr/lib/jvm/java-17-openjdk    # To avoid determining the correct path based on the architecture
     ln -s -v /usr/lib/jvm/java-17-openjdk/bin/java /usr/bin/java17          # Add java17 bin
     update-alternatives --set java /usr/lib/jvm/java-17-openjdk-*/bin/java  # Set the default openjdk version to 17
+    find /usr/lib/jvm -name 'src.zip' -delete                               # Remove leftover JDK source archives
 
     install_go                                          # Golang language
     install_ohmyzsh                                     # Awesome shell


### PR DESCRIPTION
Here some useless java install leftover:
```
 find /usr/lib/jvm -name 'src.zip' | xargs du -ch                                             
51M     /usr/lib/jvm/java-21-openjdk/lib/src.zip                                                                                                                                         
0       /usr/lib/jvm/openjdk-17/src.zip                                                                                                                                                  
56M     /usr/lib/jvm/java-11-openjdk/lib/src.zip                                                                                                                                         
0       /usr/lib/jvm/java-17-openjdk-amd64/lib/src.zip                                                                                                                                   
106M    total                                                                   
```

I think it is better to do that post java install than in the post_install function 'cause java is only installed once