### PR TITLE
chore: lighter jadx (-421Mo)

### DIFF
--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -97,6 +97,7 @@ function install_peepdf() {
 function install_jadx() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing jadx"
+    local jadx_url
     jadx_url=$(curl --location --silent "https://api.github.com/repos/skylot/jadx/releases/latest" | grep 'browser_download_url.' | grep -o 'https://[^"]*' | head -n1)
     curl --location -o /tmp/jadx.zip "$jadx_url"
     unzip -q /tmp/jadx.zip -d /opt/tools/jadx

--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -97,11 +97,11 @@ function install_peepdf() {
 function install_jadx() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing jadx"
-    git -C /opt/tools/ clone --depth 1 https://github.com/skylot/jadx.git
-    cd /opt/tools/jadx || exit
-    ./gradlew dist
-    ln -v -s /opt/tools/jadx/build/jadx/bin/jadx /opt/tools/bin/jadx
-    ln -v -s /opt/tools/jadx/build/jadx/bin/jadx-gui /opt/tools/bin/jadx-gui
+    jadx_url=$(curl --location --silent "https://api.github.com/repos/skylot/jadx/releases/latest" | grep 'browser_download_url.' | grep -o 'https://[^"]*' | head -n1)
+    curl --location -o /tmp/jadx.zip "$jadx_url"
+    unzip -q /tmp/jadx.zip -d /opt/tools/jadx
+    ln -v -s /opt/tools/jadx/bin/jadx /opt/tools/bin/jadx
+    ln -v -s /opt/tools/jadx/bin/jadx-gui /opt/tools/bin/jadx-gui
     add-history jadx
     add-test-command "jadx --help"
     add-to-list "jadx,https://github.com/skylot/jadx,Java decompiler"


### PR DESCRIPTION
Just install jadx from releases: lighter and more stable.

Before
```
# du -sh /opt/tools/jadx 
543M	/opt/tools/jadx
```

After

```
# du -sh /opt/tools/jadx 
122M    /opt/tools/jadx
```