### PR TITLE
chore: lighter chainsaw (-483Mo)

### DIFF
--- a/sources/install/package_forensic.sh
+++ b/sources/install/package_forensic.sh
@@ -115,6 +115,8 @@ function install_chainsaw() {
     cd /opt/tools/chainsaw || exit
     cargo build --release
     ln -v -s /opt/tools/chainsaw/target/release/chainsaw /opt/tools/bin/chainsaw
+    # Clean dependencies used to build the binary
+    rm -rf target/release/{deps,build,.fingerprint}
     add-history chainsaw
     add-test-command "chainsaw --help"
     add-to-list "chainsaw,https://github.com/WithSecureLabs/chainsaw,Rapidly Search and Hunt through Windows Forensic Artefacts"


### PR DESCRIPTION
We should keep the repo because chainsaw require some `rules` and `mappings` to run, but we can get rid of all build dependencies :)

Before
```
# du -sh /opt/tools/chainsaw
588M	/opt/tools/chainsaw
```

After
```
du -sh /opt/tools/chainsaw 
105M    /opt/tools/chainsaw
```

(the `rm -rf` command is the same as the one used in `legba` install function)