### PR TITLE
feat: Add Caido extension to Firefox addons

### DIFF
--- a/sources/assets/firefox/generate_policy.py
+++ b/sources/assets/firefox/generate_policy.py
@@ -21,7 +21,8 @@ names = [
     "cookie-editor",
     "wappalyzer",
     "multi-account-containers",
-    "multi-url-opener"
+    "multi-url-opener",
+    "caido-extension"
 ]
 
 def get_extension_id(extension_name):


### PR DESCRIPTION
# Description

Adds the Caido browser extension to the default Firefox addons.

# Related issues

None as far as I know. I saw [this tweet from Sytten](https://x.com/TheSytten/status/2003318240781692989) announcing the extension and thought it would be a valuable addition for Exegol users.

# Point of attention

This is my first pull request ever, please let me know if I missed anything despite trying my best to follow guidelines!