### PR TITLE
chore: wpscan history

### DIFF
--- a/sources/assets/shells/history.d/wpscan
+++ b/sources/assets/shells/history.d/wpscan
@@ -1,3 +1,4 @@
 wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --enumerate u1-20
 wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --plugins-detection aggressive
-wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --plugins-version-detection passive --password-attack xmlrpc -U 'admin' -P `fzf-wordlists`
+wpscan --api-token "$WPSCAN_API_TOKEN" --url "http://$TARGET/" --no-banner --plugins-version-detection passive
+wpscan --url "http://$TARGET/" --no-banner --password-attack xmlrpc -U 'admin' -P `fzf-wordlists` --max-threads 20


### PR DESCRIPTION
Better to split command by behavior, e.g. if I only want to bruteforce passwords
\+ api-token is useless for bruteforcing passwords