### PR TITLE
Cleaner install method for TheHavester

### DIFF
--- a/sources/assets/shells/aliases.d/theharvester
+++ b/sources/assets/shells/aliases.d/theharvester
@@ -1,1 +1,0 @@
-alias theHarvester='/opt/tools/theHarvester/venv/bin/theHarvester'

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -114,6 +114,7 @@ function install_simplyemail() {
 }
 
 function install_theharvester() {
+    # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing theHarvester"
     pipx install --python 3.13 --system-site-packages git+https://github.com/laramies/theHarvester
     add-history theharvester

--- a/sources/install/package_osint.sh
+++ b/sources/install/package_osint.sh
@@ -115,13 +115,7 @@ function install_simplyemail() {
 
 function install_theharvester() {
     colorecho "Installing theHarvester"
-    git -C /opt/tools/ clone --depth 1 https://github.com/laramies/theHarvester
-    cd /opt/tools/theHarvester || exit
-    python3.13 -m venv --system-site-packages ./venv
-    source ./venv/bin/activate
-    pip3 install .
-    deactivate
-    add-aliases theharvester
+    pipx install --python 3.13 --system-site-packages git+https://github.com/laramies/theHarvester
     add-history theharvester
     add-test-command "theHarvester --help"
     add-to-list "theharvester,https://github.com/laramies/theHarvester,Tool for gathering e-mail accounts / subdomain names / virtual host / open ports / banners / and employee names from different public sources"


### PR DESCRIPTION
# Description

This PR allow a easier install method for TheHarvester. This app allow pipx install but require Python 3.13. So I use the same trick as weevely : just specify the python version use during pipx install :)

# Related issues

N/A

# Point of attention

N/A
