### PR TITLE
chore: fast-meterpreter tweak

### DIFF
--- a/sources/assets/shells/aliases.d/metasploit
+++ b/sources/assets/shells/aliases.d/metasploit
@@ -22,10 +22,8 @@ __meterpreter_handler_helper() {
     msfconsole -x "
         use exploit/multi/handler;
         set PAYLOAD $PAYLOAD;
-        set LHOST $LHOST;
-        set LPORT $LPORT;
-        set ExitOnSession false;
-        exploit -j;
+        setg LHOST $LHOST;
+        setg LPORT $LPORT;
     "
 }
 alias meterpreter_handler_linux='__meterpreter_handler_helper linux/x86/meterpreter/reverse_tcp meterpreter_linux'


### PR DESCRIPTION
After days of using it, i find the `set ExitOnSession false; exploit -j;` super annoying cause I usually update it before running it

\+ `setg LHOST/LPORT` is quite useful when changing payloads