### PR TITLE
feat(ldapsearch): show deleted and recycled objects

### DIFF
--- a/sources/assets/shells/history.d/ldapsearch
+++ b/sources/assets/shells/history.d/ldapsearch
@@ -1,4 +1,5 @@
 ldapsearch -h "$DC_IP" -x -s "base" "namingcontexts"
 ldapsearch -h "$TARGET" -x -b "DC=DOMAIN,DC=LOCAL"
 ldapsearch -H ldap://$TARGET -x -b "DC=DOMAIN,DC=LOCAL"
-
+ldapsearch -H ldap://$TARGET -D "$USER@$DOMAIN" -w "$PASSWORD" -b "DC=DOMAIN,DC=LOCAL" -E '1.2.840.113556.1.4.417' "(isDeleted=TRUE)"
+ldapsearch -H ldap://$TARGET -D "$USER@$DOMAIN" -w "$PASSWORD" -b "DC=DOMAIN,DC=LOCAL" -E '1.2.840.113556.1.4.2064' "(isDeleted=TRUE)"

--- a/sources/assets/shells/history.d/ldapsearch
+++ b/sources/assets/shells/history.d/ldapsearch
@@ -1,5 +1,7 @@
+# Show deleted objects
+ldapsearch -H ldap://$TARGET -D "$USER@$DOMAIN" -w "$PASSWORD" -b "DC=DOMAIN,DC=LOCAL" -E '1.2.840.113556.1.4.417' "(isDeleted=TRUE)"
+# Show recycled objects
+ldapsearch -H ldap://$TARGET -D "$USER@$DOMAIN" -w "$PASSWORD" -b "DC=DOMAIN,DC=LOCAL" -E '1.2.840.113556.1.4.2064' "(isDeleted=TRUE)"
 ldapsearch -h "$DC_IP" -x -s "base" "namingcontexts"
 ldapsearch -h "$TARGET" -x -b "DC=DOMAIN,DC=LOCAL"
 ldapsearch -H ldap://$TARGET -x -b "DC=DOMAIN,DC=LOCAL"
-ldapsearch -H ldap://$TARGET -D "$USER@$DOMAIN" -w "$PASSWORD" -b "DC=DOMAIN,DC=LOCAL" -E '1.2.840.113556.1.4.417' "(isDeleted=TRUE)"
-ldapsearch -H ldap://$TARGET -D "$USER@$DOMAIN" -w "$PASSWORD" -b "DC=DOMAIN,DC=LOCAL" -E '1.2.840.113556.1.4.2064' "(isDeleted=TRUE)"


### PR DESCRIPTION
yeah 1.2.840.113556.1.4.417 and 1.2.840.113556.1.4.2064 look like magic values, but they’re actually **standard Microsoft LDAP control OIDs**: the first tells AD to show *deleted (tombstoned)* objects, and the second tells it to show *recycled objects* (when the Recycle Bin is enabled)

should we add a comment qt the end of commands to not forget and allow faster command search ??

```
ldapsearch ... -E '1.2.840.113556.1.4.417' "(isDeleted=TRUE)"  # Show deleted objects
ldapsearch ... -E '1.2.840.113556.1.4.2064' "(isDeleted=TRUE)" # Show recycled objects
```