### PR TITLE
Update Manspider installation to support ARM64 container.

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -908,17 +908,10 @@ function install_pywhisker() {
 function install_manspider() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing Manspider"
-    if [[ $(uname -m) = 'x86_64' ]]
-    then
-        pipx install --system-site-packages git+https://github.com/blacklanternsecurity/MANSPIDER
-        add-history manspider
-        add-test-command "manspider --help"
-        add-to-list "manspider,https://github.com/blacklanternsecurity/MANSPIDER,Manspider will crawl every share on every target system. If provided creds don't work it will fall back to 'guest' then to a null session."
-    else
-        # https://github.com/blacklanternsecurity/MANSPIDER/issues/55
-        criticalecho-noexit "This installation function doesn't support architecture $(uname -m)" && return
-    fi
-
+    pipx install --system-site-packages git+https://github.com/blacklanternsecurity/MANSPIDER
+    add-history manspider
+    add-test-command "manspider --help"
+    add-to-list "manspider,https://github.com/blacklanternsecurity/MANSPIDER,Manspider will crawl every share on every target system. If provided creds don't work it will fall back to 'guest' then to a null session."
 }
 
 function install_targetedKerberoast() {


### PR DESCRIPTION
# Description

Manspider have a big update recently (check the main page : https://github.com/blacklanternsecurity/MANSPIDER). They change extractous to Kreuzberg. Kreuzberg have arm64 so no issue now for ARM64 version :)

<img width="1108" height="389" alt="Capture d’écran 2026-02-08 à 20 55 38" src="https://github.com/user-attachments/assets/17bc1ab9-12b3-4dc5-8f1b-425afa749f02" />

# Related issues

No issue on Exegol but on Manspider : https://github.com/blacklanternsecurity/MANSPIDER/issues/55

# Point of attention

Kreuzberg is a rust library. During the installation, the library is compiled. So the installation is pretty long but worked. I don't know if other architecture (raspberry and so one.) worked.
