### PR TITLE
fix BHCE error in lastes version 8.5.2

### DIFF
--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -202,7 +202,13 @@ function install_bloodhound-ce() {
 
     # Build the API
     asdf set golang 1.24.4
-    sed -i 's/\s*STORAGE MAIN//' ./cmd/api/src/database/migration/migrations/v8.5.0.sql
+
+    # See https://github.com/ThePorgs/Exegol-images/pull/667
+    local temp_fix_limit="2026-08-10"
+    if check_temp_fix_expiry "$temp_fix_limit"; then
+        sed -i 's/\s*STORAGE MAIN//' ./cmd/api/src/database/migration/migrations/v8.5.0.sql
+    fi
+    
     go build -C cmd/api/src -o ${bloodhoundce_path}/bloodhound -ldflags "-X 'github.com/specterops/bloodhound/cmd/api/src/version.majorVersion=8' -X 'github.com/specterops/bloodhound/cmd/api/src/version.minorVersion=0' -X 'github.com/specterops/bloodhound/cmd/api/src/version.patchVersion=1'" github.com/specterops/bloodhound/cmd/api/src/cmd/bhapi
 
     # Force remove go and yarn cache that are not stored in standard locations

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -202,6 +202,7 @@ function install_bloodhound-ce() {
 
     # Build the API
     asdf set golang 1.24.4
+    sed -i 's/\s*STORAGE MAIN//' ./cmd/api/src/database/migration/migrations/v8.5.0.sql
     go build -C cmd/api/src -o ${bloodhoundce_path}/bloodhound -ldflags "-X 'github.com/specterops/bloodhound/cmd/api/src/version.majorVersion=8' -X 'github.com/specterops/bloodhound/cmd/api/src/version.minorVersion=0' -X 'github.com/specterops/bloodhound/cmd/api/src/version.patchVersion=1'" github.com/specterops/bloodhound/cmd/api/src/cmd/bhapi
 
     # Force remove go and yarn cache that are not stored in standard locations


### PR DESCRIPTION
# Description

>  Fixes an error in the latest BHCE update causing the tool to be unlauchable. It boils down to an undefined "STORAGE MAIN" method that is called in the 8.5 sql migration file

# Related issues

SQL  error on latest BHCE version fix ("SQLSTATE 42601")

# Point of attention

> Tested by myself, 1 specterops dev on the slack chat, and 2  laboratory rats/friends. (expect official fix in the tool soon, this is a workaround for the time being)
