### PR TITLE
Fix/msfvenom wrapper path

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -292,7 +292,7 @@ function install_mdcat() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing mdcat"
     source "$HOME/.cargo/env"
-    cargo binstall -y mdcat
+    cargo install mdcat --locked
     add-history mdcat
     add-test-command "mdcat --version"
     add-to-list "mdcat,https://github.com/swsnr/mdcat,Fancy cat for Markdown"


### PR DESCRIPTION

### What/Why

Metasploit in Exegol is mostly exposed via aliases/functions, which don’t exist in non-interactive contexts (e.g. sh -c, os.system, services, C2 servers).

This adds minimal POSIX sh wrappers in /usr/local/bin for msfconsole, msfvenom, msfdb, msfrpc, msfrpcd, msfd.

## How

Wrappers export BUNDLE_GEMFILE=/opt/tools/metasploit-framework/Gemfile and execute the real Metasploit binaries.

Prefer /usr/local/rvm/gems/ruby-*@metasploit-framework/wrappers/bundle when present; fallback to ruby -S bundle exec.


Before:

```sh -c "msfconsole --help" → not found``` 

<img width="1191" height="1390" alt="screenshot-2026-02-10_23-48-45" src="https://github.com/user-attachments/assets/58f832c7-4164-49a1-a25a-9e783327c265" />


After

sh -c "msfconsole --help"

env -i PATH=/usr/local/bin:/usr/bin:/bin msfvenom --help

Sliver: generate stager ... succeeds (no “msfvenom not found in PATH”)

<img width="1001" height="1390" alt="screenshot-2026-02-10_23-47-44" src="https://github.com/user-attachments/assets/30792afa-c913-4830-82a1-e35ba753831d" />

