### PR TITLE
fix(web): fix dirsearch broken install (missing setuptools)

### DIFF
--- a/sources/install/package_web.sh
+++ b/sources/install/package_web.sh
@@ -126,7 +126,6 @@ function install_ffuf() {
 function install_dirsearch() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing dirsearch"
-    rm -rf /opt/tools/dirsearch
     git -C /opt/tools clone --depth 1 https://github.com/maurosoria/dirsearch
     cd /opt/tools/dirsearch || exit 1
     git fetch --unshallow || true


### PR DESCRIPTION
### What changed

This PR replaces the previous temporary pipx-based installation logic for dirsearch with a deterministic venv-based install.

Changes made:

- Removed temporary expiry logic and pipx install .
- Always clone dirsearch directly into /opt/tools
- Create a dedicated virtual environment
- Explicitly install setuptools and wheel inside the venv
- Install requirements from requirements.txt
- Add a minimal /usr/local/bin/dirsearch wrapper for consistent PATH usage

### Why


During build, dirsearch fails with:
``` ModuleNotFoundError: No module named 'pkg_resources' ```

This happens because pkg_resources is provided by setuptools, which is not guaranteed to exist inside the created environment.


<img width="1701" height="688" alt="screenshot-2026-02-10_16-11-28" src="https://github.com/user-attachments/assets/7e01bbeb-c073-41e1-b5d0-4e49b4fb7c3f" />




----
### After

Installation succeeds and dirsearch works:

<img width="1191" height="688" alt="screenshot-2026-02-11_01-01-51" src="https://github.com/user-attachments/assets/0e7c034e-72c4-47e8-a4d6-829e910b946a" />

