### PR TITLE
fix(base): install mdcat via cargo --locked

### DIFF
--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -292,7 +292,7 @@ function install_mdcat() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing mdcat"
     source "$HOME/.cargo/env"
-    cargo binstall -y mdcat
+    cargo install mdcat --locked
     add-history mdcat
     add-test-command "mdcat --version"
     add-to-list "mdcat,https://github.com/swsnr/mdcat,Fancy cat for Markdown"


### PR DESCRIPTION
Fix mdcat installation by using cargo install --locked to avoid dependency resolution issues when cargo-binstall falls back to building from source. This prevents failures caused by yanked crates during CI/image builds.

Before: mdcat install fails during source build due to a yanked dependency (pulldown-cmark-mdcat = 2.7.1).
After: mdcat installs successfully and mdcat --version passes in the build pipeline.

### Before (build fail):

<img width="1101" height="1390" alt="image" src="https://github.com/user-attachments/assets/bdcf19a9-b5ff-4a1b-acac-8fb6ab3b368f" />

### After (build works):


<img width="1046" height="688" alt="image" src="https://github.com/user-attachments/assets/fa501d42-4006-4000-9b75-84ed7616dba6" />
