### PR TITLE
Add adwsdomaindump

### DIFF
--- a/sources/assets/shells/history.d/adwsdomaindump
+++ b/sources/assets/shells/history.d/adwsdomaindump
@@ -1,0 +1,1 @@
+adwsdomaindump -u "$DOMAIN"\\"$USER" -p "$PASSWORD" -n "$DC_IP" "$DC_HOST"

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -103,6 +103,16 @@ function install_ldapdomaindump() {
     add-to-list "ldapdomaindump,https://github.com/dirkjanm/ldapdomaindump,A tool for dumping domain data from an LDAP service"
 }
 
+function install_adwsdomaindump() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing adwsdomaindump"
+    # Remove --system-site-packages because the ldapdomaindump package conflicts with the base package
+    pipx install --system-site-packages git+https://github.com/mverschu/adwsdomaindump
+    add-history adwsdomaindump
+    add-test-command "adwsdomaindump --help"
+    add-to-list "adwsdomaindump,https://github.com/mverschu/adwsdomaindump,A tool for dumping domain data via ADWS for evasion purposes."
+}
+
 function install_bloodhound-py() {
     colorecho "Installing and Python ingestor for BloodHound"
     pipx install --system-site-packages git+https://github.com/fox-it/BloodHound.py
@@ -1628,6 +1638,7 @@ function package_ad() {
     install_pretender
     install_responder               # LLMNR, NBT-NS and MDNS poisoner
     install_ldapdomaindump
+    install_adwsdomaindump
     install_sprayhound              # Password spraying tool
     install_smartbrute              # Password spraying tool
     install_bloodhound-py           # ingestor for legacy BloodHound

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -106,7 +106,6 @@ function install_ldapdomaindump() {
 function install_adwsdomaindump() {
     # CODE-CHECK-WHITELIST=add-aliases
     colorecho "Installing adwsdomaindump"
-    # Remove --system-site-packages because the ldapdomaindump package conflicts with the base package
     pipx install --system-site-packages git+https://github.com/mverschu/adwsdomaindump
     add-history adwsdomaindump
     add-test-command "adwsdomaindump --help"


### PR DESCRIPTION
# Description

This PR adds ADWSDomainDump, an Active Directory information dumper leveraging ADWS (Active Directory Web Services) instead of LDAP.

The tool enables domain enumeration over port 9389 (ADWS), which can be advantageous in environments where LDAP-based enumeration is restricted, filtered, or closely monitored.

# Reference 
- https://github.com/mverschu/adwsdomaindump