### PR TITLE
feat: add ssh2john alias

### DIFF
--- a/sources/assets/shells/aliases.d/john-the-ripper
+++ b/sources/assets/shells/aliases.d/john-the-ripper
@@ -1,1 +1,2 @@
 alias john='/opt/tools/john/run/john'
+alias ssh2john='/opt/tools/john/run/ssh2john.py'


### PR DESCRIPTION
# Description

Alias for `ssh2john` was missing even though the script has been there for a while in `/opt/tools/john/run/` as `ssh2john.py`.

# Related issues

N/A.

# Point of attention

N/A.
