### PR TITLE
add arsenal-ng

### DIFF
--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -259,6 +259,17 @@ function install_nfsshell() {
     add-to-list "nfsshell,https://github.com/Supermathie/nfsshell,NFSShell is a tool for interacting with NFS shares without mounting them."
 }
 
+function install_arsenal_ng() {
+    # CODE-CHECK-WHITELIST=add-aliases
+    colorecho "Installing arsenal-ng"
+    asdf set golang 1.24.0
+    go install -v github.com/halilkirazkaya/arsenal-ng/cmd/arsenal-ng@latest
+    asdf reshim golang
+    add-history arsenal-ng
+    add-test-command "which arsenal-ng"
+    add-to-list "arsenal-ng,https://github.com/halilkirazkaya/arsenal-ng,Arsenal-NG is a modern command-line cheatsheet tool for penetration testers."
+}
+
 # Package dedicated to offensive miscellaneous tools
 function package_misc() {
     set_env
@@ -285,6 +296,7 @@ function package_misc() {
     install_thr             # https://www.thehacker.recipes/
     install_dtrx            # Intelligent archive extractor
     install_nfsshell        # NFS share interaction tool
+    install_arsenal_ng      # Cheatsheet tool for pentesters
     post_install
     end_time=$(date +%s)
     local elapsed_time=$((end_time - start_time))


### PR DESCRIPTION
# Description

Adds **arsenal-ng** (`github.com/halilkirazkaya/arsenal-ng`), a modern TUI-based pentest command launcher written in Go. It provides 200+ cybersecurity cheat-sheets with fuzzy search, syntax highlighting, argument placeholders (`{{arg}}`/`{{arg|default}}`), global variables, and terminal prefill support.

Installed via `go install` with Go 1.24.0+ requirement. The binary is tested with `which arsenal-ng` since it is a TUI application that does not support `--help` or `--version` flags.

# Related issues

N/A

# Point of attention

- Requires **Go 1.24.0+** — `asdf set golang 1.24.0` is called before install to ensure the correct version is used.
- arsenal-ng relies on `TIOCSTI` ioctl for terminal prefill on **Linux kernel 6.2+**, which is disabled by default. Users may need to enable `dev.tty.legacy_tiocsti=1` or grant `CAP_SYS_ADMIN` to the binary. This does not affect installation.
- Since it is a pure TUI app, `add-test-command "which arsenal-ng"` is used instead of a `--help` invocation to avoid hanging in non-interactive CI environments.