### PR TITLE
replaced ruby 3.1.2 with 3.2.2

### DIFF
--- a/sources/assets/shells/aliases.d/cewl
+++ b/sources/assets/shells/aliases.d/cewl
@@ -1,1 +1,1 @@
-alias cewl='/usr/local/rvm/gems/ruby-3.1.2@cewl/wrappers/ruby /opt/tools/CeWL/cewl.rb'
+alias cewl='/usr/local/rvm/gems/ruby-3.2.2@cewl/wrappers/ruby /opt/tools/CeWL/cewl.rb'

--- a/sources/assets/shells/aliases.d/evil-winrm
+++ b/sources/assets/shells/aliases.d/evil-winrm
@@ -1,1 +1,1 @@
-alias evil-winrm='/usr/local/rvm/gems/ruby-3.1.2@evil-winrm/wrappers/ruby /usr/local/rvm/gems/ruby-3.1.2@evil-winrm/bin/evil-winrm'
+alias evil-winrm='/usr/local/rvm/gems/ruby-3.2.2@evil-winrm/wrappers/ruby /usr/local/rvm/gems/ruby-3.2.2@evil-winrm/bin/evil-winrm'

--- a/sources/assets/shells/aliases.d/pass-station
+++ b/sources/assets/shells/aliases.d/pass-station
@@ -1,1 +1,1 @@
-alias pass-station='/usr/local/rvm/gems/ruby-3.1.2@pass-station/wrappers/ruby /usr/local/rvm/gems/ruby-3.1.2@pass-station/bin/pass-station'
+alias pass-station='/usr/local/rvm/gems/ruby-3.2.2@pass-station/wrappers/ruby /usr/local/rvm/gems/ruby-3.2.2@pass-station/bin/pass-station'

--- a/sources/install/package_ad.sh
+++ b/sources/install/package_ad.sh
@@ -530,7 +530,7 @@ function install_krbrelayx() {
 
 function install_evilwinrm() {
     colorecho "Installing evil-winrm"
-    rvm use 3.1.2@evil-winrm --create
+    rvm use 3.2.2@evil-winrm --create
     gem install evil-winrm
     rvm use 3.2.2@default
     add-aliases evil-winrm

--- a/sources/install/package_base.sh
+++ b/sources/install/package_base.sh
@@ -155,7 +155,6 @@ function install_rvm() {
     rvm autolibs read-fail
     rvm rvmrc warning ignore allGemfiles
     rvm use 3.2.2@default
-    rvm install ruby-3.1.2  # needed by cewl, pass-station, evil-winrm
     rvm install ruby-3.3.8  # needed by metasploit-framework
     rvm get head
     rvm cleanup all

--- a/sources/install/package_wordlists.sh
+++ b/sources/install/package_wordlists.sh
@@ -20,7 +20,7 @@ function install_wordlists_apt_tools() {
 
 function install_cewl() {
     colorecho "Installing cewl"
-    rvm use 3.1.2@cewl --create # currently does not support a version higher than 3.1.2
+    rvm use 3.2.2@cewl --create
     gem install mime mime-types mini_exiftool nokogiri rubyzip spider
     git -C /opt/tools clone --depth 1 https://github.com/digininja/CeWL.git
     bundle install --gemfile /opt/tools/CeWL/Gemfile
@@ -59,9 +59,9 @@ function install_seclists() {
 
 function install_pass_station() {
     colorecho "Installing Pass Station"
-    rvm use 3.1.2@pass-station --create # currently does not support a version higher than 3.1.2
+    rvm use 3.2.2@pass-station --create
     gem install pass-station
-    rvm use 3.1.2@default
+    rvm use 3.2.2@default
     add-aliases pass-station
     add-history pass-station
     add-test-command "pass-station --help"


### PR DESCRIPTION
# Description

Ruby 3.1.2 can be replaced with ruby 3.2.2 completely

# Related issues

#691 

# Point of attention

> Things you are not sure about that deserve special attention if you have doubts or questions.
