### PR TITLE
fix: pin workflow actions to commit SHA

### DIFF
--- a/.github/workflows/dispatch_nightly.yml
+++ b/.github/workflows/dispatch_nightly.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get latest commit title (first line only)
         id: get_commit_title
@@ -24,7 +24,7 @@ jobs:
           echo "commit_title=$sanitized_title" >> "$GITHUB_OUTPUT"
 
       - name: Trigger Pipeline Repo
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         # passing the title only, as a multi-line string is not supported
         with:
           token: ${{ secrets.PIPELINE_PAT }}

--- a/.github/workflows/dispatch_preprod_base.yml
+++ b/.github/workflows/dispatch_preprod_base.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "IMAGE_VERSION=$(echo ${{ github.event.pull_request.title }} | cut -d ' ' -f 2)" >> $GITHUB_OUTPUT
       - name: Trigger Pipeline Repo
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.PIPELINE_PAT }}
           repository: ThePorgs/Pipelines

--- a/.github/workflows/dispatch_release.yml
+++ b/.github/workflows/dispatch_release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Pipeline Repo
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.PIPELINE_PAT }}
           repository: ThePorgs/Pipelines

--- a/.github/workflows/entrypoint_pr.yml
+++ b/.github/workflows/entrypoint_pr.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check colorecho
         run: python3 ~/exegol-pipelines-tools/code_compliance_check.py colorecho
       - name: Check add-aliases
@@ -93,7 +93,7 @@ jobs:
       - name: Clean unused local volumes
         run: docker volume prune --force
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare build
         id: prepare
         run: echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT


### PR DESCRIPTION

# Description
Tags and branches in GitHub are mutable; a repository owner or an attacker who gains access to the upstream action repository can move a tag to a different commit. This creates a supply chain risk where malicious code could be introduced into our CI/CD environment without changing our workflow files.

# Related issues

None found.

# Point of attention

Make sure that the versions pinned are correct.