### PR TITLE
feat: added burp-pro trust ca

### DIFF
--- a/sources/assets/burpsuite/trust-ca-burp.sh
+++ b/sources/assets/burpsuite/trust-ca-burp.sh
@@ -56,7 +56,14 @@ function trust_ca_burp_in_firefox() {
     sed -i "s/\"listener_port\":[0-9]\+/\"listener_port\":$burp_port/g" /opt/tools/BurpSuiteCommunity/conf.json
     # Start Burp with "y" to accept policy and generate CA, keep its PID to kill it when done
     logger_debug 'Starting Burp and waiting for proxy to listen'
-    echo y|/usr/lib/jvm/java-21-openjdk/bin/java -Djava.awt.headless=true -jar /opt/tools/BurpSuiteCommunity/BurpSuiteCommunity.jar --config-file=/opt/tools/BurpSuiteCommunity/conf.json 2>&1 > /dev/null &
+
+    local $burp_pro_path="/opt/my-resources/setup/burpsuite/BurpSuitePro"
+    if [[ -f "$burp_pro_path/BurpSuitePro.jar" ]]; then
+      logger_debug 'Burpsuite pro detected'
+      echo y|/usr/lib/jvm/java-21-openjdk/bin/java -Djava.awt.headless=true -jar "$burp_pro_path/BurpSuitePro.jar" --config-file=/opt/tools/BurpSuiteCommunity/conf.json 2>&1 > /dev/null &
+    else
+      echo y|/usr/lib/jvm/java-21-openjdk/bin/java -Djava.awt.headless=true -jar /opt/tools/BurpSuiteCommunity/BurpSuiteCommunity.jar --config-file=/opt/tools/BurpSuiteCommunity/conf.json 2>&1 > /dev/null &
+    fi
     # pull the latest process's ID
     local burp_pid=$!
     # Define Timeout counter


### PR DESCRIPTION
# Description

Add automatic Burp CA trust if Burp pro is installed.

# Related issues

#109

# Point of attention

This modification assume Burp pro is installed in `my-resources`, but this also work if the install folder is copied inside the container, using `load_user_setup.sh` for example.

References:
- https://blog.gregscharf.com/2025/07/23/burp-suite-pro-install-in-exegol/
