### PR TITLE
feat: added a semgrep history, fixed a kerbrute history, download cre…

### DIFF
--- a/sources/assets/shells/history.d/kerbrute
+++ b/sources/assets/shells/history.d/kerbrute
@@ -1,5 +1,5 @@
 kerbrute userenum --domain "$DOMAIN" usernames.txt
 kerbrute passwordspray --domain "$DOMAIN" domain_users.txt Password123
 kerbrute passwordspray --user-as-pass --domain "$DOMAIN" domain_users.txt
-kerbrute bruteuser --domain "$DOMAIN" passwords.lst thoffman
+kerbrute bruteuser --domain "$DOMAIN" `fzf-wordlists` thoffman
 kerbrute bruteforce --domain "$DOMAIN" user_password.lst

--- a/sources/assets/shells/history.d/semgrep
+++ b/sources/assets/shells/history.d/semgrep
@@ -1,1 +1,2 @@
 semgrep -e '$X == $X' --lang=py path/to/src
+semgrep scan --sarif -o out.sarif .

--- a/sources/install/package_misc.sh
+++ b/sources/install/package_misc.sh
@@ -190,7 +190,7 @@ function install_creds() {
     colorecho "Installing creds"
     pipx install --system-site-packages git+https://github.com/ihebski/DefaultCreds-cheat-sheet
     add-history creds
-    add-test-command "creds version"
+    add-test-command "creds update"
     add-to-list "creds,https://github.com/ihebski/DefaultCreds-cheat-sheet,One place for all the default credentials to assist pentesters during an engagement. This document has several products default login/password gathered from multiple sources."
 }
 


### PR DESCRIPTION
# Description

Added two history and also make `creds` download the database during image creation. this is useful in case the container has a limited internet connectivity, at least the tester has the database even if he can't update it.

# Related issues

N/A

# Point of attention

N/A
