### PR TITLE
Better history cmd for DonPAPI, impacket, ADWSDomainDump

### DIFF
--- a/sources/assets/shells/history.d/adwsdomaindump
+++ b/sources/assets/shells/history.d/adwsdomaindump
@@ -1,1 +1,2 @@
-adwsdomaindump -u "$DOMAIN"\\"$USER" -p "$PASSWORD" -n "$DC_IP" "$DC_HOST"
+adwsdomaindump -u "$DOMAIN"\\"$USER" -p ":$NT_HASH" --outdir adwsdomaindump -n "$DC_IP" "$DC_HOST"
+adwsdomaindump -u "$DOMAIN"\\"$USER" -p "$PASSWORD" --outdir adwsdomaindump -n "$DC_IP" "$DC_HOST"

--- a/sources/assets/shells/history.d/donpapi
+++ b/sources/assets/shells/history.d/donpapi
@@ -1,1 +1,4 @@
-DonPAPI "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET"
+DonPAPI gui
+donpapi gui
+DonPAPI collect -u "$USER" -p "$PASSWORD" -d "$DOMAIN" -t "$TARGET"
+donpapi collect -u "$USER" -p "$PASSWORD" -d "$DOMAIN" -t "$TARGET"

--- a/sources/assets/shells/history.d/donpapi
+++ b/sources/assets/shells/history.d/donpapi
@@ -1,4 +1,3 @@
-DonPAPI gui
 donpapi gui
-DonPAPI collect -u "$USER" -p "$PASSWORD" -d "$DOMAIN" -t "$TARGET"
+donpapi collect -u "$USER" -H ":$NT_HASH" -d "$DOMAIN" -t "$TARGET"
 donpapi collect -u "$USER" -p "$PASSWORD" -d "$DOMAIN" -t "$TARGET"

--- a/sources/assets/shells/history.d/impacket
+++ b/sources/assets/shells/history.d/impacket
@@ -74,6 +74,7 @@ mssqlclient.py "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET" -windows-auth
 dpapi.py credential -file "$CRED_FILE" -key "$DECRYPTED_MASTERKEY"
 dpapi.py masterkey -file "$MASTERKEY_FILE" -sid "$USER_SID" -hash "$NT_HASH"
 dpapi.py masterkey -file "$MASTERKEY_FILE" -sid "$USER_SID" -password "$MASTERKEY_PASSWORD"
+dpapi.py masterkey -file "$MASTERKEY_FILE" -pvk "$BACKUP_KEY"
 dpapi.py backupkeys --export -t "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET"
 describeTicket.py "$CCACHE_PATH"
 tgssub.py -in "$CCACHE_PATH" -altservice "cifs/$HOSTNAME.$DOMAIN" -out newticket-cifs.ccache

--- a/sources/assets/shells/history.d/impacket
+++ b/sources/assets/shells/history.d/impacket
@@ -70,6 +70,11 @@ changepasswd.py -newpass '123Pentest!!!' "$DOMAIN"/"$USER":"$PASSWORD"@"$DC_HOST
 changepasswd.py -newpass '123Pentest!!!' -hashes :"$NT_HASH" "$DOMAIN"/"$USER"@"$TARGET"
 owneredit.py -action write -new-owner "$NEW_OWNER" -target "$TARGET_OBJECT" "$DOMAIN"/"$USER":"$PASSWORD"
 mssqlclient.py "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET"
+mssqlclient.py "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET" -windows-auth
+dpapi.py credential -file "$CRED_FILE" -key "$DECRYPTED_MASTERKEY"
+dpapi.py masterkey -file "$MASTERKEY_FILE" -sid "$USER_SID" -hash "$NT_HASH"
+dpapi.py masterkey -file "$MASTERKEY_FILE" -sid "$USER_SID" -password "$MASTERKEY_PASSWORD"
+dpapi.py backupkeys --export -t "$DOMAIN"/"$USER":"$PASSWORD"@"$TARGET"
 describeTicket.py "$CCACHE_PATH"
 tgssub.py -in "$CCACHE_PATH" -altservice "cifs/$HOSTNAME.$DOMAIN" -out newticket-cifs.ccache
 tgssub.py -in "$CCACHE_PATH" -altservice "http/$HOSTNAME.$DOMAIN" -out newticket-http.ccache


### PR DESCRIPTION
# Description

This PR improves the command history by adding new entries for DonPAPI, impacket, ADWSDomainDump.

The following commands have been added or updated:
- **mssqlclient.py** : Windows authentication support via domain credentials
- **dpapi.py** : Multiple DPAPI scenarios: masterkey decryption (via hash or password), backup keys export, and credential file decryption
- **DonPAPI** :  Fix incorrect syntax and add gui mode
- **adwsdomaindump** : add outdir directory (like ldapdomaindump) and NTLM auth
